### PR TITLE
chore: install clang toolset and gdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ docker run -ti --rm \
 | `cs`                |`<https://get-coursier.io/>`         |
 | `sbt`               |`<sbt launch script>`                |
 | `mill`              |`<mill launch script>`               |
+|--------C/CPP--------|-------------------------------------|
+| `clang`             |`clang`                              |
+| `clangd`            |`llvm-toolset`                       |
+| `gdb`               |`gdb`                                |
 |-------NODEJS--------|-------------------------------------|
 | `nodejs`            |`nodejs`                             |
 | `npm`               |`npm`                                |
@@ -93,7 +97,7 @@ docker run -ti --rm \
 | `python`            |`python39`                           |
 | `setuptools`        |`python39-setuptools`                |
 | `pip`               |`python39-pip`                       |
-| `pylint`            |`<via pip>`                       |
+| `pylint`            |`<via pip>`                          |
 |------CLOUD----------|-------------------------------------|
 | `podman`            |`container-tools:rhel8`              |
 | `buildah`           |`container-tools:rhel8`              |

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -57,12 +57,15 @@ RUN curl -fLo sbt https://raw.githubusercontent.com/dwijnand/sbt-extras/master/s
 RUN curl -fLo mill https://raw.githubusercontent.com/lefou/millw/main/millw && \
     chmod +x mill && \
     mv mill /usr/local/bin/
+    
+# C/CPP
+RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra gdb
 
 # NodeJS
 ENV NODEJS_VERSION=14
 RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
     dnf -y update && \
-    dnf -y install make gcc gcc-c++ libatomic_ops git openssl-devel \
+    dnf -y install make libatomic_ops openssl-devel \
                    nodejs npm nodejs-nodemon nss_wrapper && \
     dnf -y clean all --enablerepo='*' && \
     npm install --global yarn


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

- Install `gdb`, `clangd` and `clang` with libraries
- Remove `git` from universal image since it was installed in base image  