### PR TITLE
feat: Add Java8 and Java17

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ docker run -ti --rm \
 |---------------------|-------------------------------------|
 |--------JAVA---------|-------------------------------------|
 | `sdk`               |`<https://get.sdkman.io>`            |
-| `java`              |`<11.0.12-open via sdkman>`          |
+| `java`              |`<8.0.302-open via sdkman>`          |
+| `java`              |`<11.0.12-open via sdkman>/default`  |
+| `java`              |`<17.0.1-open via sdkman>`           |
 | `maven`             |`<via sdkman>`                       |
 | `gradle`            |`<via sdkman>`                       |
 |--------SCALA--------|-------------------------------------|
@@ -121,12 +123,12 @@ docker run -ti --rm \
 | `terraform`         |`<releases.hashicorp.com>`           |
 | `docker`            |`<download.docker.com>`              |
 | `docker-compose`    |`<gh releases>`                      |
-| **TOTAL SIZE**      | **6.03GB** (2.21GB compressed)      |
+| **TOTAL SIZE**      | **6.5GB** (2.5GB compressed)      |
 
+### Environment Variables
 
-
-
-
+#### Java
+JAVA_HOME_8, JAVA_HOME_11, JAVA_HOME_17
 
 
 

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -21,11 +21,20 @@ USER 10001
 # Java
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /home/user/.sdkman/bin/sdkman-init.sh \
+             && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/user/.sdkman/etc/config \
+             && sdk install java 8.0.302-open \
              && sdk install java 11.0.12-open \
+             && sdk install java 17.0.1-open \
+             && sdk default java 11.0.12-open \
              && sdk install gradle \
              && sdk install maven \
              && sdk flush archives \
              && sdk flush temp"
+
+# sdk home java <version>
+ENV JAVA_HOME_8=/home/user/.sdkman/candidates/java/8.0.302-open
+ENV JAVA_HOME_11=/home/user/.sdkman/candidates/java/11.0.12-open
+ENV JAVA_HOME_17=/home/user/.sdkman/candidates/java/17.0.1-open
 
 # Java-related environment variables are described and set by /home/user/.bashrc
 # To make Java working for dash and other shells, it needs to initialize them in the Dockerfile.


### PR DESCRIPTION
default is still Java11

Fixes https://github.com/eclipse/che/issues/20793