### PR TITLE
Fix GH action publishing the wrong base image

### DIFF
--- a/.github/workflows/ubi8-build.yaml
+++ b/.github/workflows/ubi8-build.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
 
-  build_ubi8_images:
-    name: Build and publish ubi8 images to Quay.io
+  build_base_ubi8_image:
+    name: Build and publish base ubi8 image to Quay.io
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -19,7 +19,6 @@ jobs:
         with:
           images: |
             quay.io/devfile/base-developer-image
-            quay.io/devfile/universal-developer-image
           flavor: |
             latest=true
             prefix=ubi8-,onlatest=true
@@ -42,6 +41,34 @@ jobs:
           context: base/ubi8
           tags: |
             ${{ steps.meta.outputs.tags }}
+
+  build_universal_ubi8_image:
+    name: Build and publish universal ubi8 image to Quay.io
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/devfile/universal-developer-image
+          flavor: |
+            latest=true
+            prefix=ubi8-,onlatest=true
+          tags: |
+            type=sha,prefix=ubi8-,format=short
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Quay.io
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Docker Build & Push Universal
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
The current base image published on Quay.io is identical to the universal image.

That happens because the image built from `universal/ubi8/Dockerfile` is tagged and published as both `quay.io/devfile/base-developer-image` and `quay.io/devfile/universal-developer-image`.

This PR separate the 2 builds in 2 distinct jobs.

Fixes https://github.com/eclipse/che/issues/20798
