### PR TITLE
feat: add yq library to operate with yaml files from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ docker run -ti --rm \
 | `setuptools`        |`python39-setuptools`                |
 | `pip`               |`python39-pip`                       |
 | `pylint`            |`<via pip>`                          |
+| `yq`                |`<via pip>`                          |
 |--------RUST---------|-------------------------------------|
 | `rustup`            |`<sh.rustup.rs>`                     |
 | `rust-src`          |`<via rustup>`                       |

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -103,7 +103,7 @@ RUN cd /usr/bin \
     && if [ ! -L python-config ]; then ln -s python3.9-config python-config; fi \
     && if [ ! -L pip ]; then ln -s pip-3.9 pip; fi
 
-RUN pip install pylint
+RUN pip install pylint yq
 
 # PHP
 ENV PHP_VERSION=7.4


### PR DESCRIPTION
This changes proposal adds `yq` library that installs via `pip` to allow to parse yaml files from the command line. Like it done with JSON files with `jq`.

Part of https://github.com/eclipse/che/issues/21003

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>