### PR TITLE
feat: CRW-2698 update UDI to node16 in both...

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -78,7 +78,7 @@ RUN curl -fLo mill https://raw.githubusercontent.com/lefou/millw/main/millw && \
 RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra gdb
 
 # NodeJS
-ENV NODEJS_VERSION=14
+ENV NODEJS_VERSION=16
 RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
     dnf -y update && \
     dnf -y install make libatomic_ops openssl-devel \


### PR DESCRIPTION
feat: CRW-2698 update UDI to node16 in both Che UDI and CRW UDI images (note: NOT TESTED, no idea if this will break devfiles/plugins)

Change-Id: Id7afab48ba79422285c58303b65f0e43d4e52b36
Signed-off-by: nickboldt <nboldt@redhat.com>