### PR TITLE
chore: add mandrel (downstream distribution of the GraalVM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ docker run -ti --rm \
 | `java`              |`<17.0.1-open via sdkman>`           |
 | `maven`             |`<via sdkman>`                       |
 | `gradle`            |`<via sdkman>`                       |
+| `mandrel`           |`<via sdkman>`                       |
 |--------SCALA--------|-------------------------------------|
 | `cs`                |`<https://get-coursier.io/>`         |
 | `sbt`               |`<sbt launch script>`                |
@@ -127,7 +128,7 @@ docker run -ti --rm \
 | `terraform`         |`<releases.hashicorp.com>`           |
 | `docker`            |`<download.docker.com>`              |
 | `docker-compose`    |`<gh releases>`                      |
-| **TOTAL SIZE**      | **7.04GB** (2.7GB compressed)       |
+| **TOTAL SIZE**      | **8.34GB** (2.7GB compressed)       |
 
 ### Included libraries
 
@@ -137,12 +138,3 @@ docker run -ti --rm \
 
 #### Java
 JAVA_HOME_8, JAVA_HOME_11, JAVA_HOME_17
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker run -ti --rm \
 | `java`              |`<17.0.1-open via sdkman>`           |
 | `maven`             |`<via sdkman>`                       |
 | `gradle`            |`<via sdkman>`                       |
-| `mandrel`           |`<via sdkman>`                       |
+| `mandrel`           |`<22.1.0.0.r11-mandrel via sdkman>`  |
 |--------SCALA--------|-------------------------------------|
 | `cs`                |`<https://get-coursier.io/>`         |
 | `sbt`               |`<sbt launch script>`                |

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
              && sdk install java 8.0.302-open \
              && sdk install java 11.0.12-open \
              && sdk install java 17.0.1-open \
+             && sdk install java 22.1.0.0.r11-mandrel \
              && sdk default java 11.0.12-open \
              && sdk install gradle \
              && sdk install maven \
@@ -47,6 +48,8 @@ ENV SDKMAN_VERSION="5.13.0"
 ENV GRADLE_HOME="/home/user/.sdkman/candidates/gradle/current"
 ENV JAVA_HOME="/home/user/.sdkman/candidates/java/current"
 ENV MAVEN_HOME="/home/user/.sdkman/candidates/maven/current"
+
+ENV GRAALVM_HOME=/home/user/.sdkman/candidates/java/22.1.0.0.r11-mandrel
 
 ENV PATH="/home/user/.krew/bin:$PATH"
 ENV PATH="/home/user/.sdkman/candidates/maven/current/bin:$PATH"


### PR DESCRIPTION
Install [mandrel](https://github.com/graalvm/mandrel) (downstream distribution of the GraalVM community edition)

Size of installed Mandrel is 408M 

Related issue: https://github.com/eclipse/che/issues/21145

Signed-off-by: svor <vsvydenk@redhat.com>