### PR TITLE
Feat: Small change to add shasum for chectl

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -21,7 +21,7 @@ USER 0
 
 RUN dnf update -y && \
     dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps \
-                   net-tools openssh-clients rsync socat sudo time vim wget zip && \
+                   net-tools openssh-clients rsync shasum socat sudo time vim wget zip && \
                    dnf clean all
 
 ## gh-cli

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -152,7 +152,6 @@ ENV KAMEL_VERSION 1.9.2
 RUN curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/kamel
 
-
 # Cloud
 
 # oc
@@ -166,6 +165,9 @@ RUN dnf -y module enable container-tools:rhel8 && \
     dnf -y reinstall shadow-utils && \
     dnf -y install podman buildah skopeo fuse-overlayfs && \
     dnf -y clean all --enablerepo='*'
+
+# shasum
+RUN dnf -y install shasum
 
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -166,9 +166,6 @@ RUN dnf -y module enable container-tools:rhel8 && \
     dnf -y install podman buildah skopeo fuse-overlayfs && \
     dnf -y clean all --enablerepo='*'
 
-# shasum
-RUN dnf -y install shasum
-
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to
 # isolate the filesystem with chroot.


### PR DESCRIPTION
Issue: che-incubator/chectl#2239
The chectl package-binaries command uses shasum, so we either have to add shasum to the image used to create a workspace or add a symlink from sha256sum (which we do have).

Steps to reproduce: 
- Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute (my branch that contains the build fixes).
- Build Chectl
- Run the package-binaries command
- command fails with `/bin/sh: shasum: command not found`

Steps to verify:
- Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute. It uses the latest ubi image by default.
- Build Chectl
- Run the package-binaries command
