### PR TITLE
fix: Updating links to the quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Containers images with tools for developers 👨‍💻👩‍💻
 
 ## Developer Base Image
 
-### Red Hat Universal Base Image ([UBI](https://developers.redhat.com/articles/ubi-faq#)) based image ([quay.io/devfile/base-developer-image:ubi8-latest](https://quay.io/repository/devfile/base-developer-image/))
+### Red Hat Universal Base Image ([UBI](https://developers.redhat.com/articles/ubi-faq#)) based image ([quay.io/devfile/base-developer-image:ubi8-latest](https://quay.io/repository/devfile/base-developer-image))
 
 Run the following command to test it with Docker:
 
@@ -60,7 +60,7 @@ $ docker run -ti --rm \
 
 ## Developer Universal Image
 
-### Red Hat Universal Base Image ([UBI](https://developers.redhat.com/articles/ubi-faq#)) based image ([quay.io/devfile/universal-developer-image:ubi8-latest](https://quay.io/repository/devfile/universal-developer-image/))
+### Red Hat Universal Base Image ([UBI](https://developers.redhat.com/articles/ubi-faq#)) based image ([quay.io/devfile/universal-developer-image:ubi8-latest](https://quay.io/repository/devfile/universal-developer-image))
 
 Run the following command to test it with Docker: 
 


### PR DESCRIPTION
For some reason trailing `/` is not redirecting correctly on the quay.io e.g. valid link https://quay.io/repository/devfile/universal-developer-image vs invalid https://quay.io/repository/devfile/universal-developer-image/ (results in `Repository not found`)