### PR TITLE
Fix: actual install command is perl-Digest-SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ docker run -ti --rm \
 | `scp`               |`openssh-clients`                    |
 | `screen`            |`NOT AVAILABLE`                      |
 | `sed`               |`sed`                                |
+| `shasum`            |`perl-Digest-SHA`                    |
 | `socat`             |`socat`                              |
 | `sudo`              |`sudo`                               |
 | `ss`                |`NOT AVAILABLE`                      |

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -21,7 +21,7 @@ USER 0
 
 RUN dnf update -y && \
     dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps \
-                   net-tools openssh-clients rsync shasum socat sudo time vim wget zip && \
+                   perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip && \
                    dnf clean all
 
 ## gh-cli


### PR DESCRIPTION
Fix to previous PR. I noticed the image build failed because shasum is a perl script and not actually equivalent to sha1sum.

Issue: che-incubator/chectl#2239
The chectl package-binaries command uses shasum, so we either have to add shasum to the image used to create a workspace or add a symlink from sha256sum (which we do have).

Steps to reproduce: 
- Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute (my branch that contains the build fixes).
- Build Chectl
- Run the package-binaries command
- command fails with `/bin/sh: shasum: command not found`

Steps to verify:
- Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute. It uses the latest ubi image by default.
- Build Chectl
- Run the package-binaries command
