### PR TITLE
fix: add p7zip-plugins to base image for chectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ docker run -ti --rm \
 | `netcat`            |`NOT AVAILABLE`                      |
 | `netstat`           |`net-tools`                          |
 | `openssh-client`    |`openssh-clients`                    |
+| `7z`                |`p7zip-plugins`                      |
 | `ripgrep`           |`<gh releases>`                      |
 | `rsync`             |`rsync`                              |
 | `scp`               |`openssh-clients`                    |
@@ -131,7 +132,7 @@ docker run -ti --rm \
 | `docker`            |`<download.docker.com>`              |
 | `docker-compose`    |`<gh releases>`                      |
 | `kamel`            |`<gh release>`                     |
-| **TOTAL SIZE**      | **8.34GB** (2.7GB compressed)       |
+| **TOTAL SIZE**      | **8.75GB** (3.6GB compressed)       |
 
 ### Included libraries
 

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -20,7 +20,7 @@ LABEL io.openshift.expose-services=""
 USER 0
 
 RUN dnf update -y && \
-    dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps \
+    dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps p7zip-plugins \
                    perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip && \
                    dnf clean all
 


### PR DESCRIPTION
Fix to previous PR. I noticed the image build failed because shasum is a perl script and not actually equivalent to sha1sum.

Issue: https://github.com/che-incubator/chectl/pull/2239
The chectl package-binaries command also packages for windows and needs 7zip to do so.
I also noticed that the sizes in the readme were slightly out of date so I updated the compressed size to match the size in quay and the uncompressed size to how big they were when running locally.

Steps to reproduce:
   - Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute (my branch that contains the build fixes).
  - Build Chectl
  - Run the package-binaries command
    command fails:
`oclif-dev: building target chectl-win32-x64.tar.gz
/bin/sh: 7z: command not found
 ›   Error: install 7-zip to package windows tarball
error Command failed with exit code 2.`

Steps to verify:
  - Create a Chectl workspace in the che dogfooding instance from https://github.com/SDawley/chectl/tree/contribute. It uses the latest ubi image by default.
  - Build Chectl
  - Run the package-binaries command