### PR TITLE
Fix: add epel repo so p7zip can be found.

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -19,8 +19,9 @@ LABEL io.openshift.expose-services=""
 
 USER 0
 
-RUN dnf update -y && \
-    dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps p7zip-plugins \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf update -y && \
+    dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps p7zip p7zip-plugins \
                    perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip && \
                    dnf clean all
 


### PR DESCRIPTION
Fix to previous PR. 

Issue: https://github.com/che-incubator/chectl/pull/2239
epel needs to be added so that 7zip can be found and installed

Steps to reproduce:
https://github.com/devfile/developer-images/actions/runs/3274136656/jobs/5387344563
`#9 3.828 No match for argument: p7zip-plugins
#9 3.834 Error: Unable to find a match: p7zip-plugins`

Steps to verify:
- Build the dockerfile successfully