### PR TITLE
chore: CRW-3445 backport update to...

### DIFF
--- a/base/ubi8/entrypoint.sh
+++ b/base/ubi8/entrypoint.sh
@@ -6,8 +6,8 @@ if [ ! -d "${HOME}" ]; then
 fi
 
 # Setup $PS1 for a consistent and reasonable prompt
-if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
-  echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc
+if [ -w "${HOME}" ]; then
+  echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> "${HOME}"/.bashrc
 fi
 
 # Add current (arbitrary) user to /etc/passwd and /etc/group


### PR DESCRIPTION
chore: CRW-3445 backport update to downstream UDI image into Che UDI image - remove user and add git branch to prompt

Signed-off-by: Nick Boldt <nboldt@redhat.com>