### PR TITLE
chore: CRW-3445 backport update to...

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 
 FROM registry.access.redhat.com/ubi8/ubi
-
 LABEL maintainer="Red Hat, Inc."
 
 LABEL com.redhat.component="devfile-base-container"
@@ -76,12 +75,16 @@ cd -
 rm -rf "${TEMP_DIR}"
 EOF
 
-# Set permissions on /etc/passwd and /home to allow arbitrary users to write
+
 COPY --chown=0:0 entrypoint.sh /
-RUN mkdir -p /home/user && chgrp -R 0 /home && \
+RUN mkdir -p /home/user && \
+    # Setup $PS1 for a consistent and reasonable prompt
+    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> "${HOME}"/.bashrc && \
     # Copy the global git configuration to user config as global /etc/gitconfig
     #  file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig /home/user/.gitconfig && \
+    # Set permissions on /etc/passwd and /home to allow arbitrary users to write
+    chgrp -R 0 /home && \
     chmod -R g=u /etc/passwd /etc/group /home && \
     chmod +x /entrypoint.sh
 

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -25,61 +25,56 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
                    dnf clean all
 
 ## gh-cli
-RUN <<EOF
-set -euf -o pipefail
-TEMP_DIR="$(mktemp -d)"
-cd "${TEMP_DIR}"
-GH_VERSION="2.0.0"
-GH_ARCH="linux_amd64"
-GH_TGZ="gh_${GH_VERSION}_${GH_ARCH}.tar.gz"
-GH_TGZ_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TGZ}"
-GH_CHEKSUMS_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt"
-curl -sSLO "${GH_TGZ_URL}"
-curl -sSLO "${GH_CHEKSUMS_URL}"
-sha256sum --ignore-missing -c "gh_${GH_VERSION}_checksums.txt" 2>&1 | grep OK
-tar -zxvf "${GH_TGZ}"
-mv "gh_${GH_VERSION}_${GH_ARCH}"/bin/gh /usr/local/bin/
-cd -
-rm -rf "${TEMP_DIR}"
-EOF
+RUN \
+    TEMP_DIR="$(mktemp -d)"; \
+    cd "${TEMP_DIR}"; \
+    GH_VERSION="2.0.0"; \
+    GH_ARCH="linux_amd64"; \
+    GH_TGZ="gh_${GH_VERSION}_${GH_ARCH}.tar.gz"; \
+    GH_TGZ_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TGZ}"; \
+    GH_CHEKSUMS_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt"; \
+    curl -sSLO "${GH_TGZ_URL}"; \
+    curl -sSLO "${GH_CHEKSUMS_URL}"; \
+    sha256sum --ignore-missing -c "gh_${GH_VERSION}_checksums.txt" 2>&1 | grep OK; \
+    tar -zxvf "${GH_TGZ}"; \
+    mv "gh_${GH_VERSION}_${GH_ARCH}"/bin/gh /usr/local/bin/; \
+    cd -; \
+    rm -rf "${TEMP_DIR}"
 
 ## ripgrep
-RUN <<EOF
-set -euf -o pipefail
-TEMP_DIR="$(mktemp -d)"
-cd "${TEMP_DIR}"
-RG_VERSION="13.0.0"
-RG_ARCH="x86_64-unknown-linux-musl"
-RG_TGZ="ripgrep-${RG_VERSION}-${RG_ARCH}.tar.gz"
-RG_TGZ_URL="https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TGZ}"
-curl -sSLO "${RG_TGZ_URL}"
-tar -zxvf "${RG_TGZ}"
-mv "ripgrep-${RG_VERSION}-${RG_ARCH}"/rg /usr/local/bin/
-cd -
-rm -rf "${TEMP_DIR}"
-EOF
+RUN \
+    TEMP_DIR="$(mktemp -d)"; \
+    cd "${TEMP_DIR}"; \
+    RG_VERSION="13.0.0"; \
+    RG_ARCH="x86_64-unknown-linux-musl"; \
+    RG_TGZ="ripgrep-${RG_VERSION}-${RG_ARCH}.tar.gz"; \
+    RG_TGZ_URL="https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TGZ}"; \
+    curl -sSLO "${RG_TGZ_URL}"; \
+    tar -zxvf "${RG_TGZ}"; \
+    mv "ripgrep-${RG_VERSION}-${RG_ARCH}"/rg /usr/local/bin/; \
+    cd -; \
+    rm -rf "${TEMP_DIR}"
 
 ## bat
-RUN <<EOF
-set -euf -o pipefail
-TEMP_DIR="$(mktemp -d)"
-cd "${TEMP_DIR}"
-BAT_VERSION="0.18.3"
-BAT_ARCH="x86_64-unknown-linux-musl"
-BAT_TGZ="bat-v${BAT_VERSION}-${BAT_ARCH}.tar.gz"
-BAT_TGZ_URL="https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/${BAT_TGZ}"
-curl -sSLO "${BAT_TGZ_URL}"
-tar -zxvf "${BAT_TGZ}"
-mv "bat-v${BAT_VERSION}-${BAT_ARCH}"/bat /usr/local/bin/
-cd -
-rm -rf "${TEMP_DIR}"
-EOF
-
+RUN \
+    TEMP_DIR="$(mktemp -d)"; \
+    cd "${TEMP_DIR}"; \
+    BAT_VERSION="0.18.3"; \
+    BAT_ARCH="x86_64-unknown-linux-musl"; \
+    BAT_TGZ="bat-v${BAT_VERSION}-${BAT_ARCH}.tar.gz"; \
+    BAT_TGZ_URL="https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/${BAT_TGZ}"; \
+    curl -sSLO "${BAT_TGZ_URL}"; \
+    tar -zxvf "${BAT_TGZ}"; \
+    mv "bat-v${BAT_VERSION}-${BAT_ARCH}"/bat /usr/local/bin/; \
+    cd -; \
+    rm -rf "${TEMP_DIR}"
 
 COPY --chown=0:0 entrypoint.sh /
-RUN mkdir -p /home/user && \
+RUN \
+    # add user and configure it
+    useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \
     # Setup $PS1 for a consistent and reasonable prompt
-    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> "${HOME}"/.bashrc && \
+    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> /home/user/.bashrc && \
     # Copy the global git configuration to user config as global /etc/gitconfig
     #  file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig /home/user/.gitconfig && \


### PR DESCRIPTION
chore: CRW-3445 backport update to downstream UDI image into Che UDI image - remove user and add git branch to prompt (add to Dockerfile, not entrypoint.sh)

Signed-off-by: Nick Boldt <nboldt@redhat.com>