### PR TITLE
Add `git-lfs` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ docker run -ti --rm \
 | `fish`              |`NOT AVAILABLE (fedora only)`        |
 | `gh`                |`<gh releases>`                      |
 | `git`               |`git`                                |
+| `git-lfs`           |`git-lfs`                            |
 | `ip`                |`iproute`                            |
 | `jq`                |`jq`                                 |
 | `htop`              |`NOT AVAILABLE (fedora only)`        |


### PR DESCRIPTION
Add `git-lfs` to `README.md` as it's included in the base-developer-image
https://github.com/devfile/developer-images/blob/13008afdefb64f16c906c6d8b2aeb58deae8f8c2/base/ubi8/Dockerfile#L23