### PR TITLE
Add comments so dockerfiles can be updated by update-base-images

### DIFF
--- a/.github/workflows/ubi8-build.yaml
+++ b/.github/workflows/ubi8-build.yaml
@@ -40,6 +40,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           context: base/ubi8
           tags: |
+            quay.io/devfile/base-developer-image:latest
             ${{ steps.meta.outputs.tags }}
 
   build_universal_ubi8_image:

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM registry.access.redhat.com/ubi8/ubi
+# https://registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8/ubi:8.7-1026
 LABEL maintainer="Red Hat, Inc."
 
 LABEL com.redhat.component="devfile-base-container"

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
-# https://quay.io/devfile/base-developer-image
-FROM quay.io/devfile/base-developer-image:ubi8-13008af
+# updateBaseImages.sh can't operate on SHA-based tags as they're not date-based or semver-sequential, and therefore cannot be ordered
+FROM quay.io/devfile/base-developer-image:ubi8-latest
 LABEL maintainer="Red Hat, Inc."
 
 LABEL com.redhat.component="devfile-universal-container"

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM quay.io/devfile/base-developer-image:ubi8-latest
+# https://quay.io/devfile/base-developer-image
+FROM quay.io/devfile/base-developer-image:ubi8-13008af
 LABEL maintainer="Red Hat, Inc."
 
 LABEL com.redhat.component="devfile-universal-container"


### PR DESCRIPTION
Changes for https://github.com/eclipse/che/issues/21575
Set the dockerfiles to use a specific tag and added the commented html line which should allow the update-base-images action to keep them up to date.