### PR TITLE
Upgrade Kamel CLI to 1.11.0

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -148,7 +148,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSfo rustup https://sh.rustup.rs && \
     rustup -y --no-modify-path --profile minimal -c rust-src -c rust-analysis -c rls
 
 # camel-k
-ENV KAMEL_VERSION 1.9.2
+ENV KAMEL_VERSION 1.11.0
 RUN curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/kamel
 


### PR DESCRIPTION
Version 1.9.2 is fairly old (5/2022) and there are many new core features in Kamel 1.11.0

I tested the "curl" command locally :
```
$ cat curl.sh
KAMEL_VERSION=1.11.0
curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C . -xz%
$ ./curl.sh
./curl.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 50 30.5M   50 15.4M    0     0  2018k      0  0:00:15  0:00:07  0:00:08 2697k
 80 30.5M   80 24.6M    0     0  2854k      0  0:00:10  0:00:08  0:00:02 4219k
100 30.5M  100 30.5M    0     0  3341k      0  0:00:09  0:00:09 --:--:-- 5583k
$ ls | grep kamel
kamel
kamel.sha512
```
and it worked just fine, so the image should be built successfully.