### PR TITLE
Build linux/arm64 ubi9 base image in GH action

### DIFF
--- a/.github/workflows/ubi9-build.yaml
+++ b/.github/workflows/ubi9-build.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           context: base/ubi9
+          platforms: linux/amd64, linux/arm64
           tags: |
             quay.io/devfile/base-developer-image:ubi9-latest
             ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Added `platforms: linux/amd64` in ubi9 build.