### PR TITLE
Set sdkman_auto_env: true

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -23,6 +23,7 @@ USER 10001
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /home/user/.sdkman/bin/sdkman-init.sh \
              && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/user/.sdkman/etc/config \
+	     && sed -i "s/sdkman_auto_env=false/sdkman_auto_env=true/g" /home/user/.sdkman/etc/config \
              && sdk install java 8.0.332-tem \
              && sdk install java 11.0.15-tem \
              && sdk install java 17.0.3-tem \


### PR DESCRIPTION
Setting `sdkman_auto_env` so that [`.sdkmanrc` is automatically used](https://sdkman.io/usage#env).

For testing I have build and push the image `quay.io/mloriedo/universal-developer-image:ubi8-latest` and used this [devfile](https://github.com/l0rd/inventory-quarkus/blob/sdkman_auto_env/.devfile.yaml#L111).