### PR TITLE
chore: update dotnet version to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker run -ti --rm \
 | `go`                |`go-toolset`                         |
 | `gopls`             |`golang.org/x/tools/gopls`           |
 |--------.NET---------|-------------------------------------|
-| `dotnet`            |`dotnet-sdk-5.0`                     |
+| `dotnet`            |`dotnet-sdk-6.0`                     |
 |------PYTHON---------|-------------------------------------|
 | `python`            |`python39`                           |
 | `setuptools`        |`python39-setuptools`                |

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -136,7 +136,7 @@ ENV PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear \
     HTTPD_VAR_PATH=/var
 
 # .NET
-ENV DOTNET_RPM_VERSION=5.0
+ENV DOTNET_RPM_VERSION=6.0
 RUN dnf install -y dotnet-hostfxr-${DOTNET_RPM_VERSION} dotnet-runtime-${DOTNET_RPM_VERSION} dotnet-sdk-${DOTNET_RPM_VERSION}
 
 # rust


### PR DESCRIPTION
Update dotnet version to 6.0

Related issues: https://github.com/eclipse/che/issues/22077, https://github.com/eclipse/che/issues/21978