### PR TITLE
Add action for testing UDI images

### DIFF
--- a/.github/workflows/empty-worksapce-smoke-test-on-minikube.yaml
+++ b/.github/workflows/empty-worksapce-smoke-test-on-minikube.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+name: Empty workspace API test
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - devfile.yaml
+      - LICENSE
+
+
+env:
+   USERSTORY: CloneGitRepoAPI
+   TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL: kubectl
+   DEPLOYMENT_TIMEOUT: 90s
+
+jobs:
+  build_image_runner:
+    # reuse existing workflow
+    uses: ./.github/workflows/ubi8-build.yaml
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+  workspace-api-tests-on-minikube:
+    runs-on: ubuntu-22.04
+    needs: build_image_runner
+    env:
+      imageTag: ${{ needs.build_image_runner.outputs.uniq_tag }}
+    steps:
+    - name: Read artifact
+      run: |
+        echo ${{ env.imageTag }}
+
+    - name: Checkout WTO
+      uses: actions/checkout@master
+      with:
+        repository: devfile/devworkspace-operator
+        path: devworkspace-operator
+
+    - name: Checkout tests codebase
+      uses: actions/checkout@master
+      with:
+        repository: eclipse/che
+        path: che
+ 
+    - name: Install NodeJs
+      uses: actions/setup-node@v3
+
+    - name: Start minikube cluster
+      id: run-minikube
+      uses: che-incubator/setup-minikube-action@next
+      with:
+        minikube-version: v1.23.2
+
+    - name: Setup cert manager
+      run: |
+        cd devworkspace-operator
+        make install_cert_manager
+        kubectl wait deployment -n cert-manager cert-manager --for condition=Available=True --timeout=$DEPLOYMENT_TIMEOUT
+        kubectl wait deployment -n cert-manager cert-manager-cainjector --for condition=Available=True --timeout=$DEPLOYMENT_TIMEOUT
+        kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=$DEPLOYMENT_TIMEOUT
+
+    - name: Setup DWO
+      run: |
+        cd devworkspace-operator
+        make install
+
+    - name: Pre-pull image on minikube
+      run: |
+        minikube ssh "docker pull ${{ env.imageTag }}"
+
+    - name: Run Empty workspace smoke test
+      run: |
+        export TS_API_TEST_UDI_IMAGE=${{ env.imageTag }}
+        cd che/tests/e2e
+        npm i
+        npm run driver-less-test
+

--- a/.github/workflows/ubi8-build.yaml
+++ b/.github/workflows/ubi8-build.yaml
@@ -1,9 +1,21 @@
-
 name: Build of UBI 8 based Developer Images
 
 on:
   push:
     branches: [ main ]
+
+  workflow_call:
+    # Map the workflow outputs to job outputs
+    secrets:
+      QUAY_USERNAME:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+    outputs:
+      uniq_tag:
+        description: "The first output string"
+        value: ${{ jobs.build_universal_ubi8_image.outputs.output1 }}
+
 
 jobs:
   build_base_ubi8_image:
@@ -28,7 +40,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Quay.io
-        uses: docker/login-action@v2 
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -47,6 +59,9 @@ jobs:
     name: Build and publish universal ubi8 image to Quay.io
     runs-on: ubuntu-22.04
     needs: build_base_ubi8_image
+   # job output for passing to mapping value (the workflow_call section)
+    outputs:
+      output1: ${{ steps.setTagName.outputs.uniq_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +81,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Quay.io
-        uses: docker/login-action@v2 
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -80,3 +95,11 @@ jobs:
           tags: |
             quay.io/devfile/universal-developer-image:latest
             ${{ steps.meta.outputs.tags }}
+      - name: Get tag with uniq prefix
+        id: setTagName
+        # set the image with uniq tag prefix (for example: quay.io/..../base-developer-image:ubi8-7ad6cab) to env. var
+        # and define it for output. This output with tag image will be used in caller job
+        run: |
+          UNIQ_TAG_IMAGE=$(echo $DOCKER_METADATA_OUTPUT_JSON | jq .tags[0])
+          echo "...................$UNIQ_TAG_IMAGE"
+          echo "uniq_tag=$UNIQ_TAG_IMAGE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
* This PR adds a check-up on each opened PR that makes the next steps:
1) reusing Job which builds UDI-8 image and builds a new image
2) after success building the just created tag pass to the Empty workspace test workflow
3) Empty workspace test workflow run the minikube set the DWO + cert-manager and pre-pull image which was created in the previous workflow
4) After this run test which creates an Empty workspace on the image and tests basic functionality (check that workspace is leave, clone repo into container)
![Selection_008](https://github.com/devfile/developer-images/assets/1640058/7f15c4b1-025b-44a9-82a5-debd0856041b)
![Selection_007](https://github.com/devfile/developer-images/assets/1640058/343add20-9712-4864-8033-2155d746d11f)
