### PR TITLE
feat: Add $GOBIN to $PATH

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -102,6 +102,8 @@ RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra g
 # gopls 0.10+ - installed to /home/user/go/bin/gopls and /home/user/go/pkg/mod/
 RUN dnf install -y go-toolset && \
     GO111MODULE=on go install -v golang.org/x/tools/gopls@latest
+ENV GOBIN="/home/user/go/bin/"
+ENV PATH="$GOBIN:$PATH"
 
 # Python
 RUN dnf -y module enable python39:3.9 && \


### PR DESCRIPTION
Fixes eclipse/che#22132.

Tested by building the UDI image, running it in docker, checking the value of $GOBIN and ensuring its on $PATH:

```
projects $ echo $GOBIN
/home/user/go/bin/

projects $ echo $PATH | grep "/go/bin/"
/home/user/.krew/bin:/home/user/.sdkman/candidates/jbang/current/bin:/home/user/.local/bin:/home/user/bin:/usr/share/Modules/bin:/home/user/.cargo/bin:/home/user/go/bin/:/home/user/.nvm/versions/node/v16.14.0/bin:/home/user/.local/share/coursier/bin:/home/user/.sdkman/candidates/gradle/current/bin:/home/user/.sdkman/candidates/java/current/bin:/home/user/.sdkman/candidates/maven/current/bin:/home/user/.krew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/.dotnet/tools
```