### PR TITLE
feat: add support to run kubedock at workspace startup

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -216,6 +216,10 @@ curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl
 echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/user/.bashrc
 EOF
 
+# kubectl completion
+RUN kubectl completion bash > /usr/share/bash-completion/completions/kubectl \
+    && echo "source /usr/share/bash-completion/completions/kubectl" >> /home/user/.bashrc
+
 ## shellcheck
 RUN <<EOF
 dnf install -y xz

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -197,6 +197,15 @@ RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; \
 RUN mkdir -p "${HOME}"/.config/containers && \
    (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf
 
+# Install kubedock
+ENV KUBEDOCK_VERSION 0.11.0
+RUN curl -L https://github.com/joyrex2001/kubedock/releases/download/${KUBEDOCK_VERSION}/kubedock_${KUBEDOCK_VERSION}_linux_amd64.tar.gz | tar -C /usr/local/bin -xz \
+    && chmod +x /usr/local/bin/kubedock
+
+# Configure the podman wrapper
+COPY --chown=0:0 podman-wrapper.sh /usr/bin/podman.wrapper
+RUN mv /usr/bin/podman /usr/bin/podman.orig
+
 ## kubectl
 RUN <<EOF
 set -euf -o pipefail
@@ -436,5 +445,7 @@ RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/gro
 
 # cleanup dnf cache
 RUN dnf -y clean all --enablerepo='*'
+
+COPY --chown=0:0 entrypoint.sh /
 
 USER 10001

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Kubedock
+if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
+    echo
+    echo "Kubedock is enabled (env variable KUBEDOCK_ENABLED is set to true)."
+
+    SECONDS=0
+    until [ -f /home/user/.kube/config ]; do
+        if (( SECONDS > 10 )); then
+            echo "Giving up..."
+            exit 1
+        fi
+        echo "Kubeconfig doesn't exist yet. Waiting..."
+        sleep 1
+    done
+    echo "Kubeconfig found."
+
+    KUBEDOCK_PARAMS=${KUBEDOCK_PARAMS:-"--reverse-proxy"}
+
+    echo "Starting kubedock with params \"${KUBEDOCK_PARAMS}\"..."
+    
+    kubedock server "${KUBEDOCK_PARAMS}" > /tmp/kubedock.log 2>&1 &
+    
+    echo "Done."
+
+    echo "Replacing podman with podman-wrapper..."
+
+    mkdir -p /home/user/.local/bin/
+    ln -f -s /usr/bin/podman.wrapper /home/user/.local/bin/podman
+
+    export TESTCONTAINERS_RYUK_DISABLED="true"
+    export TESTCONTAINERS_CHECKS_DISABLE="true"
+
+    echo "Done."
+    echo
+else
+    echo
+    echo "Kubedock is disabled. It can be enabled with the env variable \"KUBEDOCK_ENABLED=true\""
+    echo "set in the workspace Devfile or in a Kubernetes ConfigMap in the developer namespace."
+    echo
+    mkdir -p /home/user/.local/bin/
+    ln -f -s /usr/bin/podman.orig /home/user/.local/bin/podman
+fi
+
+exec "$@"

--- a/universal/ubi8/podman-wrapper.sh
+++ b/universal/ubi8/podman-wrapper.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+ORIGINAL_PODMAN_PATH=${ORIGINAL_PODMAN_PATH:-"/usr/bin/podman.orig"}
+KUBEDOCK_SUPPORTED_COMMANDS=${KUBEDOCK_SUPPORTED_COMMANDS:-"run ps exec cp logs inspect kill rm wait stop start"}
+
+PODMAN_ARGS=( "$@" )
+
+TRUE=0
+FALSE=1
+
+exec_original_podman() {
+    exec ${ORIGINAL_PODMAN_PATH} "${PODMAN_ARGS[@]}"
+}
+
+exec_kubedock_podman() {
+    exec env CONTAINER_HOST=tcp://127.0.0.1:2475 "${ORIGINAL_PODMAN_PATH}" "${PODMAN_ARGS[@]}"
+}
+
+podman_command() {
+    echo "${PODMAN_ARGS[0]}"
+}
+
+command_is_supported_by_kubedock() {
+    CMD=$(podman_command)
+    for SUPPORTED_CMD in $KUBEDOCK_SUPPORTED_COMMANDS; do
+        if [ "$SUPPORTED_CMD" = "$CMD" ]; then
+            return $TRUE
+        fi
+    done
+    return ${FALSE}
+}
+
+if command_is_supported_by_kubedock; then
+  exec_kubedock_podman
+else
+  exec_original_podman
+fi


### PR DESCRIPTION
This PR partially addresses https://github.com/eclipse/che/issues/20227. 

## Using kubedock to `run` containers and local podman to `build` containers

The approach of this PR is to add [`kubedock`](https://github.com/joyrex2001/kubedock/) in the universal developer image (Eclipse Che default image) and start it automatically if the env variable `KUBEDOCK_ENABLED` is set to `true` (can be set using a devfile).

When `KUBEDOCK_ENABLED=true` then the following commands will be executed with kubedock (the remaining commands, in particular `podman build`, will be executed by the local podman):

```
podman run
podman ps
podman exec
podman cp
podman logs
podman inspect
podman kill
podman rm
podman wait
podman stop
podman start
```

## The limits of this approach

The `kubedock` approach allows to run containers from a container running on Kubernetes but has a few limits:
- `podman build -t <image> . && podman run <image>` doesn't work and should be replaced with `podman build -t <image> . && podman push <image> && podman run <image>`. That's because kubedock runs the container as a Kubernetes pod and, as a result, the kubelet on the node will try to pull `<image>` and will fail if it cannot find it.
- Clients that use the podman or docker API need to be configured to point to kubedock setting `CONTAINER_HOST=tcp://127.0.0.1:2475` or `DOCKER_HOST=tcp://127.0.0.1:2475` when they run containers and configured to point to local `podman` when building the container (something impracticable in some cases).
- Some `podman` comands such as `generate kube` are not supported yet
- If the option `--env` is provided then the command `podman run` fails  

## How to test

I have pushed this image to `quay.io/mloriedo/universal-developer-image:kubedock-wrapper`. 

The PR can be tested on sandbox using the repo `https://github.com/l0rd/dockerfile-hello-world`:

- [with kubedock support disabled (to check that podman build works as before)](https://workspaces.openshift.com/#https://github.com/l0rd/dockerfile-hello-world/?image=quay.io/mloriedo/universal-developer-image:kubedock-wrapper)
- [with kubedock support enabled (to check that podman build/push/run works)](https://workspaces.openshift.com/#https://github.com/l0rd/dockerfile-hello-world/tree/kubedock)

