### PR TITLE
feat: add kubectl auto-completion

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -213,7 +213,10 @@ EOF2
 
 dnf install -y kubectl
 curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
+kubectl completion bash > /usr/share/bash-completion/completions/kubectl
+
 echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/user/.bashrc
+echo "source /usr/share/bash-completion/completions/kubectl" >> /home/user/.bashrc
 EOF
 
 ## shellcheck


### PR DESCRIPTION
Resolves the last part of https://github.com/eclipse/che/issues/21735 by adding bash autocompletion for kubectl.

To test, use the following image `quay.io/aobuchow/universal-developer-image:kubectl-completion`, i.e.:

```
docker run -ti --rm \
       quay.io/aobuchow/universal-developer-image:kubectl-completion \
       bash
```

Then, with a shell inside the container, type in `kubectl -` and hit TAB twice to see autocomplete results.
The output should resemble the following:

```
projects $ kubectl -
--add-dir-header            --client-key                --log-dir=                  --namespace=                --skip-log-headers          --v=
--alsologtostderr           --client-key=               --log-file                  --password                  --stderrthreshold           --vmodule
--as                        --cluster                   --log-file-max-size         --password=                 --stderrthreshold=          --vmodule=
--as-group                  --cluster=                  --log-file-max-size=        --profile                   --tls-server-name           --warnings-as-errors
--as-group=                 --context                   --log-file=                 --profile-output            --tls-server-name=          -n
--as=                       --context=                  --log-flush-frequency       --profile-output=           --token                     -s
--cache-dir                 --insecure-skip-tls-verify  --log-flush-frequency=      --profile=                  --token=                    -v
--cache-dir=                --kubeconfig                --loglevel                  --request-timeout           --user                      
--certificate-authority     --kubeconfig=               --loglevel=                 --request-timeout=          --user=                     
--certificate-authority=    --log-backtrace-at          --logtostderr               --server                    --username                  
--client-certificate        --log-backtrace-at=         --match-server-version      --server=                   --username=                 
--client-certificate=       --log-dir                   --namespace                 --skip-headers              --v 
```
