### PR TITLE
Organize bash completions

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -162,17 +162,12 @@ ENV KAMEL_VERSION 1.11.0
 RUN curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/kamel
 
-# git completion
-RUN echo "source /usr/share/bash-completion/completions/git" >> /home/user/.bashrc
-
 # Cloud
 
-# oc client and completion
+# oc client
 ENV OC_VERSION=4.6
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xz \
-    && chmod +x /usr/local/bin/oc  \
-    && oc completion bash > /usr/share/bash-completion/completions/oc \
-    && echo "source /usr/share/bash-completion/completions/oc" >> /home/user/.bashrc
+    && chmod +x /usr/local/bin/oc
 
 ## podman buildah skopeo
 RUN dnf -y module enable container-tools:rhel8 && \
@@ -228,10 +223,6 @@ dnf install -y kubectl
 curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
 echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/user/.bashrc
 EOF
-
-# kubectl completion
-RUN kubectl completion bash > /usr/share/bash-completion/completions/kubectl \
-    && echo "source /usr/share/bash-completion/completions/kubectl" >> /home/user/.bashrc
 
 ## shellcheck
 RUN <<EOF
@@ -444,6 +435,16 @@ cd -
 rm -rf "${TEMP_DIR}"
 EOF
 
+# Bash completions
+RUN dnf -y install bash-completion \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
+
+RUN <<EOF
+echo "source /etc/profile.d/bash_completion.sh" >> /home/user/.bashrc
+oc completion bash > /usr/share/bash-completion/completions/oc 
+kubectl completion bash > /usr/share/bash-completion/completions/kubectl
+EOF
 
 # Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
 # NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -20,7 +20,7 @@ LABEL io.openshift.expose-services=""
 USER 10001
 
 # Java
-RUN curl -fsSL "https://get.sdkman.io" | bash \
+RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
     && bash -c ". /home/user/.sdkman/bin/sdkman-init.sh \
              && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/user/.sdkman/etc/config \
 	     && sed -i "s/sdkman_auto_env=false/sdkman_auto_env=true/g" /home/user/.sdkman/etc/config \
@@ -443,6 +443,12 @@ make install-libs
 cd -
 rm -rf "${TEMP_DIR}"
 EOF
+
+
+# Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
+# NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly
+RUN echo 'export SDKMAN_DIR="/home/user/.sdkman"' >> /home/user/.bashrc
+RUN echo '[[ -s "/home/user/.sdkman/bin/sdkman-init.sh" ]] && source "/home/user/.sdkman/bin/sdkman-init.sh"' >> /home/user/.bashrc
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -66,9 +66,11 @@ ENV NVM_DIR="/home/user/.nvm"
 ENV NODEJS_VERSION=16.14.0
 ENV NODEJS_12_VERSION=12.22.10
 ENV NODEJS_14_VERSION=14.19.0
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash &&\
-    source /home/user/.bashrc && nvm install v${NODEJS_VERSION} && nvm install v${NODEJS_14_VERSION} && nvm install v${NODEJS_12_VERSION} && nvm alias default v$NODEJS_VERSION && nvm use v$NODEJS_VERSION && npm install --global yarn@v1.22.17 &&\
-    chgrp -R 0 /home/user && chmod -R g=u /home/user
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | PROFILE=/dev/null bash
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/user/.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/user/.bashrc
+RUN source /home/user/.bashrc && nvm install v${NODEJS_VERSION} && nvm install v${NODEJS_14_VERSION} && nvm install v${NODEJS_12_VERSION} && nvm alias default v$NODEJS_VERSION && nvm use v$NODEJS_VERSION && npm install --global yarn@v1.22.17 \
+    && chgrp -R 0 /home/user && chmod -R g=u /home/user
 ENV PATH=$NVM_DIR/versions/node/v$NODEJS_VERSION/bin:$PATH
 ENV NODEJS_HOME_12=$NVM_DIR/versions/node/v$NODEJS_12_VERSION
 ENV NODEJS_HOME_14=$NVM_DIR/versions/node/v$NODEJS_14_VERSION
@@ -444,6 +446,7 @@ RUN <<EOF
 echo "source /etc/profile.d/bash_completion.sh" >> /home/user/.bashrc
 oc completion bash > /usr/share/bash-completion/completions/oc 
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
+cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
 EOF
 
 # Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install


### PR DESCRIPTION
This PR aims to resolve eclipse/che#22411.

## What does this PR change?
The following changes are made:
1. The `rcupdate=false` request parameter is used when installing sdkman to prevent the `.bashrc`  from being automatically modified. 
2. The sdkman init script launcher is now being manually added to the end of the `.bashrc`. In my testing, running the `sdk` command still worked prior to this change, however, having the sdkman init script at the end of the `.bashrc` is recommended.
3. There is now a section dedicated to bash completions at the end of the UDI dockerfile. 
4. The `bash-completion` package was added and `/etc/profile.d/bash_completion.sh` is being sourced in the  `.bashrc`, so that all completions stored in `/usr/share/bash-completion/completions/` are now active.  This has a side-effect of installing additional completions that were previously not enabled, such as `flock`.
5. The nvm installer is no longer automatically modifying the `.bashrc`. Instead, we now manually source `nvm.sh` in the `.bashrc`, and add the nvm completions to `/usr/share/bash-completion/completions/`

This PR could be improved to remove direct reference to `/usr/share/bash-completion/completions/` and instead use pkg-config to obtain this location, [as is done in WTO](https://github.com/redhat-developer/web-terminal-tooling/blob/b0ffeb64ee771c1efd91acd3ff9efd7d27173985/Dockerfile#L29). I opted not to do this to prevent bringing in pkg-config as an additional dependency, however I'd be happy to change this.

Prior to this PR, the `/home/user/.bashrc` resembled the following:

```bash
# .bashrc

# Source global definitions
if [ -f /etc/bashrc ]; then
        . /etc/bashrc
fi

# User specific environment
if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
then
    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
fi
export PATH

# Uncomment the following line if you don't like systemctl's auto-paging feature:
# export SYSTEMD_PAGER=

# User specific aliases and functions
export PS1='\W `git branch --show-current 2>/dev/null | sed -r -e "s@^(.+)@\(\1\) @"`$ '

#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
export SDKMAN_DIR="$HOME/.sdkman"
[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
source /usr/share/bash-completion/completions/git
source /usr/share/bash-completion/completions/oc
[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases
export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
```

With the changes from this PR, the `/home/user/.bashrc` is now:

```bash
# .bashrc

# Source global definitions
if [ -f /etc/bashrc ]; then
        . /etc/bashrc
fi

# User specific environment
if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
then
    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
fi
export PATH

# Uncomment the following line if you don't like systemctl's auto-paging feature:
# export SYSTEMD_PAGER=

# User specific aliases and functions
export PS1='\W `git branch --show-current 2>/dev/null | sed -r -e "s@^(.+)@\(\1\) @"`$ '
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases
export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
source /etc/profile.d/bash_completion.sh
export SDKMAN_DIR="/home/user/.sdkman"
[[ -s "/home/user/.sdkman/bin/sdkman-init.sh" ]] && source "/home/user/.sdkman/bin/sdkman-init.sh"
```

## Testing
I've pushed `quay.io/aobuchow/universal-developer-image:bash-completions` to test the changes from this PR.

To ensure nothing broke:
1. Test `kubectl` completions by typing in `kubectl -` and hitting TAB twice.
2. Test `oc` completions by typing in `oc -` and hitting TAB twice.
3. Test `nvm` completions by typing in `nvm` and hitting TAB twice.
4. Test `git` completions by typing in `git` and hitting TAB twice.
5. Test sdkman by typing in `sdk` and hitting ENTER to make sure sdkman's help info appears.
