### PR TITLE
Don't manually add Node to PATH

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -69,7 +69,6 @@ ENV NODEJS_14_VERSION=14.19.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash &&\
     source /home/user/.bashrc && nvm install v${NODEJS_VERSION} && nvm install v${NODEJS_14_VERSION} && nvm install v${NODEJS_12_VERSION} && nvm alias default v$NODEJS_VERSION && nvm use v$NODEJS_VERSION && npm install --global yarn@v1.22.17 &&\
     chgrp -R 0 /home/user && chmod -R g=u /home/user
-ENV PATH=$NVM_DIR/versions/node/v$NODEJS_VERSION/bin:$PATH
 ENV NODEJS_HOME_12=$NVM_DIR/versions/node/v$NODEJS_12_VERSION
 ENV NODEJS_HOME_14=$NVM_DIR/versions/node/v$NODEJS_14_VERSION
 ENV NODEJS_HOME_16=$NVM_DIR/versions/node/v$NODEJS_VERSION


### PR DESCRIPTION
Removes the manual modification of PATH in the Dockerfile as running `nvm use v$NODEJS_VERSION` accomplishes this in a more reliable way. 

I've pushed `quay.io/aobuchow/universal-developer-image:no-node-on-path` to test the changes from this PR.
To verify Node still works as expected, run `node --version` and ensure the output is still `v16.14.0`.

Additionally, here's a comparison of PATH before and after this change.
Before:

```bash
$ echo $PATH | tr : \\n | sort
/bin
/home/user/.cargo/bin
/home/user/.dotnet/tools
/home/user/.krew/bin
/home/user/.krew/bin
/home/user/.local/bin
/home/user/.local/share/coursier/bin
/home/user/.nvm/versions/node/v16.14.0/bin
/home/user/.sdkman/candidates/gradle/current/bin
/home/user/.sdkman/candidates/java/current/bin
/home/user/.sdkman/candidates/jbang/current/bin
/home/user/.sdkman/candidates/maven/current/bin
/home/user/bin
/home/user/go/bin/
/sbin
/usr/bin
/usr/local/bin
/usr/local/sbin
/usr/sbin
/usr/share/Modules/bin
```


After:

```
$ echo $PATH | tr : \\n | sort
/bin
/home/user/.cargo/bin
/home/user/.dotnet/tools
/home/user/.krew/bin
/home/user/.krew/bin
/home/user/.local/bin
/home/user/.local/share/coursier/bin
/home/user/.nvm/versions/node/v16.14.0/bin
/home/user/.sdkman/candidates/gradle/current/bin
/home/user/.sdkman/candidates/java/current/bin
/home/user/.sdkman/candidates/jbang/current/bin
/home/user/.sdkman/candidates/maven/current/bin
/home/user/bin
/home/user/go/bin/
/sbin
/usr/bin
/usr/local/bin
/usr/local/sbin
/usr/sbin
/usr/share/Modules/bin
```

Side note: [Krew is being added to PATH twice](https://github.com/devfile/developer-images/blob/main/universal/ubi8/Dockerfile#L269-L270). I'll create an issue for this.  

Fix eclipse/che#22436