### PR TITLE
Move tools & configs from /home/user/ to /home/tooling/

### DIFF
--- a/base/ubi8/.stow-local-ignore
+++ b/base/ubi8/.stow-local-ignore
@@ -1,2 +1,7 @@
 # .viminfo cannot be a symlink for security reasons
 \.viminfo
+
+# We store bash related files in /home/tooling/ so they aren't overriden if persistUserHome is enabled
+# but we don't want them to be symbolic links (or to cause stow conflicts). They will be copied to /home/user/ manually.
+\.bashrc
+\.bash_profile

--- a/base/ubi8/.stow-local-ignore
+++ b/base/ubi8/.stow-local-ignore
@@ -1,0 +1,2 @@
+# .viminfo cannot be a symlink for security reasons
+\.viminfo

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -19,10 +19,13 @@ LABEL io.openshift.expose-services=""
 
 USER 0
 
+ENV HOME=/home/tooling
+RUN mkdir -p /home/tooling/
+
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf update -y && \
     dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps p7zip p7zip-plugins \
-                   perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip && \
+                   perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip stow && \
                    dnf clean all
 
 ## gh-cli
@@ -92,16 +95,22 @@ COPY --chown=0:0 entrypoint.sh /
 RUN \
     # add user and configure it
     useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \
+    # useradd will give us our default .bashrc
+    cp /home/user/.bashrc /home/tooling/.bashrc && \
+    # /home/user/.bashrc will be replaced with the a symlink from /home/tooling/.bashrc
+    rm /home/user/.bashrc  && \
     # Setup $PS1 for a consistent and reasonable prompt
-    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> /home/user/.bashrc && \
+    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> ${HOME}/.bashrc && \
     # Copy the global git configuration to user config as global /etc/gitconfig
     #  file may be overwritten by a mounted file at runtime
-    cp /etc/gitconfig /home/user/.gitconfig && \
-    chown 10001 /home/user/.gitconfig && \
+    cp /etc/gitconfig ${HOME}/.gitconfig && \
+    chown -R 10001 ${HOME}/ && \
     # Set permissions on /etc/passwd and /home to allow arbitrary users to write
     chgrp -R 0 /home && \
     chmod -R g=u /etc/passwd /etc/group /home && \
-    chmod +x /entrypoint.sh
+    chmod +x /entrypoint.sh && \
+    # Create symbolic links from /home/tooling/ -> /home/user/
+    stow . -t /home/user/ -d /home/tooling/ --no-folding
 
 USER 10001
 ENV HOME=/home/user

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -96,14 +96,12 @@ COPY --chown=0:0 .stow-local-ignore /home/tooling/
 RUN \
     # add user and configure it
     useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \
-    # useradd will give us our default .bashrc
-    cp /home/user/.bashrc /home/tooling/.bashrc && \
-    # /home/user/.bashrc will be replaced with the a symlink from /home/tooling/.bashrc
-    rm /home/user/.bashrc  && \
     # Setup $PS1 for a consistent and reasonable prompt
-    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> ${HOME}/.bashrc && \
+    touch /etc/profile.d/udi_prompt.sh && \
+    chown 10001 /etc/profile.d/udi_prompt.sh && \
+    echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> /etc/profile.d/udi_prompt.sh && \
     # Copy the global git configuration to user config as global /etc/gitconfig
-    #  file may be overwritten by a mounted file at runtime
+    # file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig ${HOME}/.gitconfig && \
     chown -R 10001 ${HOME}/ && \
     # Set permissions on /etc/passwd and /home to allow arbitrary users to write

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -92,6 +92,7 @@ RUN \
     rm -rf "${TEMP_DIR}"
 
 COPY --chown=0:0 entrypoint.sh /
+COPY --chown=0:0 .stow-local-ignore /home/tooling/
 RUN \
     # add user and configure it
     useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \
@@ -110,7 +111,9 @@ RUN \
     chmod -R g=u /etc/passwd /etc/group /home && \
     chmod +x /entrypoint.sh && \
     # Create symbolic links from /home/tooling/ -> /home/user/
-    stow . -t /home/user/ -d /home/tooling/ --no-folding
+    stow . -t /home/user/ -d /home/tooling/ --no-folding && \
+    # .viminfo cannot be a symbolic link for security reasons, so copy it to /home/user/
+    cp /home/tooling/.viminfo /home/user/.viminfo
 
 USER 10001
 ENV HOME=/home/user

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -111,7 +111,7 @@ RUN \
     chmod -R g=u /etc/passwd /etc/group /home && \
     chmod +x /entrypoint.sh && \
     # Create symbolic links from /home/tooling/ -> /home/user/
-    stow . -t /home/user/ -d /home/tooling/ --no-folding && \
+    stow . -t /home/user/ -d /home/tooling/ && \
     # .viminfo cannot be a symbolic link for security reasons, so copy it to /home/user/
     cp /home/tooling/.viminfo /home/user/.viminfo
 

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -111,7 +111,11 @@ RUN \
     # Create symbolic links from /home/tooling/ -> /home/user/
     stow . -t /home/user/ -d /home/tooling/ && \
     # .viminfo cannot be a symbolic link for security reasons, so copy it to /home/user/
-    cp /home/tooling/.viminfo /home/user/.viminfo
+    cp /home/tooling/.viminfo /home/user/.viminfo && \
+    # Bash-related files are backed up to /home/tooling/ incase they are deleted when persistUserHome is enabled.
+    cp /home/user/.bashrc /home/tooling/.bashrc && \
+    cp /home/user/.bash_profile /home/tooling/.bash_profile && \
+    chown 10001 /home/tooling/.bashrc /home/tooling/.bash_profile
 
 USER 10001
 ENV HOME=/home/user

--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -103,7 +103,7 @@ RUN \
     # Copy the global git configuration to user config as global /etc/gitconfig
     # file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig ${HOME}/.gitconfig && \
-    chown -R 10001 ${HOME}/ && \
+    chown 10001 ${HOME}/ ${HOME}/.viminfo ${HOME}/.gitconfig ${HOME}/.stow-local-ignore && \
     # Set permissions on /etc/passwd and /home to allow arbitrary users to write
     chgrp -R 0 /home && \
     chmod -R g=u /etc/passwd /etc/group /home && \

--- a/base/ubi8/entrypoint.sh
+++ b/base/ubi8/entrypoint.sh
@@ -5,11 +5,6 @@ if [ ! -d "${HOME}" ]; then
   mkdir -p "${HOME}"
 fi
 
-# Setup $PS1 for a consistent and reasonable prompt
-if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
-  echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc
-fi
-
 # Add current (arbitrary) user to /etc/passwd and /etc/group
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -170,17 +170,12 @@ ENV KAMEL_VERSION 1.11.0
 RUN curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/kamel
 
-# git completion
-RUN echo "source /usr/share/bash-completion/completions/git" >> /home/user/.bashrc
-
 # Cloud
 
-# oc client and completion
+# oc client
 ENV OC_VERSION=4.6
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xz \
-    && chmod +x /usr/local/bin/oc  \
-    && oc completion bash > /usr/share/bash-completion/completions/oc \
-    && echo "source /usr/share/bash-completion/completions/oc" >> /home/user/.bashrc
+    && chmod +x /usr/local/bin/oc
 
 ## podman buildah skopeo
 RUN dnf -y module enable container-tools:rhel8 && \
@@ -237,10 +232,6 @@ dnf install -y kubectl
 curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
 echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/user/.bashrc
 EOF
-
-# kubectl completion
-RUN kubectl completion bash > /usr/share/bash-completion/completions/kubectl \
-    && echo "source /usr/share/bash-completion/completions/kubectl" >> /home/user/.bashrc
 
 ## shellcheck
 RUN <<EOF
@@ -414,6 +405,16 @@ cd -
 rm -rf "${TEMP_DIR}"
 EOF
 
+# Bash completions
+RUN dnf -y install bash-completion \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
+
+RUN <<EOF
+echo "source /etc/profile.d/bash_completion.sh" >> /home/user/.bashrc
+oc completion bash > /usr/share/bash-completion/completions/oc 
+kubectl completion bash > /usr/share/bash-completion/completions/kubectl
+EOF
 
 # Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
 # NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -67,7 +67,10 @@ ENV NODEJS_20_VERSION=20.7.0
 # note that 18.18.0 is the latest but 18.16.1 is the supported version downstream and in ubi8
 ENV NODEJS_18_VERSION=18.16.1
 ENV NODEJS_DEFAULT_VERSION=${NODEJS_18_VERSION}
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash && source /home/user/.bashrc && \
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | PROFILE=/dev/null bash
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/user/.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/user/.bashrc
+RUN source /home/user/.bashrc && \
     nvm install v${NODEJS_20_VERSION} && \
     nvm install v${NODEJS_18_VERSION} && \
     nvm alias default v${NODEJS_DEFAULT_VERSION} && nvm use v${NODEJS_DEFAULT_VERSION} && \
@@ -414,6 +417,7 @@ RUN <<EOF
 echo "source /etc/profile.d/bash_completion.sh" >> /home/user/.bashrc
 oc completion bash > /usr/share/bash-completion/completions/oc 
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
+cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
 EOF
 
 # Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -85,15 +85,15 @@ ENV NODEJS_HOME_20=$NVM_DIR/versions/node/v${NODEJS_20_VERSION}
 ENV NODEJS_HOME_18=$NVM_DIR/versions/node/v${NODEJS_18_VERSION}
 
 # kube
-# The Che User Dashboard creates the kube config in /home/user/ and not /home/tooling/
 ENV KUBECONFIG=/home/user/.kube/config
 
 USER 0
 
 # Define user directory for binaries
-RUN mkdir -p /home/user/.local/bin && \
+RUN mkdir -p /home/tooling/.local/bin && \
     chgrp -R 0 /home && chmod -R g=u /home
 ENV PATH="/home/user/.local/bin:$PATH"
+ENV PATH="/home/tooling/.local/bin:$PATH"
 
 # Required packages for AWT
 RUN dnf install -y libXext libXrender libXtst libXi
@@ -430,12 +430,12 @@ EOF
 RUN echo 'export SDKMAN_DIR="/home/tooling/.sdkman"' >> /home/tooling/.bashrc
 RUN echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"' >> /home/tooling/.bashrc
 
-# Set permissions on /etc/passwd and /home to allow arbitrary users to write
-RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
 
 # Create symbolic links from /home/tooling/ -> /home/user/
 RUN stow . -t /home/user/ -d /home/tooling/ --no-folding
 
+# Set permissions on /etc/passwd and /home to allow arbitrary users to write
+RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
 
 # cleanup dnf cache
 RUN dnf -y clean all --enablerepo='*'

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -19,11 +19,19 @@ LABEL io.openshift.expose-services=""
 
 USER 10001
 
+# We install everything to /home/tooling/ as /home/user/ may get overriden, see github.com/eclipse/che/issues/22412
+RUN mkdir -p /home/tooling/
+ENV HOME=/home/tooling
+
+RUN cp /home/user/.bashrc /home/tooling/.bashrc
+# /home/user/.bashrc will be replaced with the a symlink from /home/tooling/.bashrc
+RUN rm /home/user/.bashrc    
+
 # Java
 RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
-    && bash -c ". /home/user/.sdkman/bin/sdkman-init.sh \
-             && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/user/.sdkman/etc/config \
-	     && sed -i "s/sdkman_auto_env=false/sdkman_auto_env=true/g" /home/user/.sdkman/etc/config \
+    && bash -c ". /home/tooling/.sdkman/bin/sdkman-init.sh \
+             && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/tooling/.sdkman/etc/config \
+	     && sed -i "s/sdkman_auto_env=false/sdkman_auto_env=true/g" /home/tooling/.sdkman/etc/config \
              && sdk install java 8.0.332-tem \
              && sdk install java 11.0.15-tem \
              && sdk install java 17.0.3-tem \
@@ -34,53 +42,55 @@ RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
              && sdk install jbang \
              && sdk flush archives \
              && sdk flush temp" \
-    && chgrp -R 0 /home/user && chmod -R g=u /home/user
+    && chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
 
 # sdk home java <version>
-ENV JAVA_HOME_8=/home/user/.sdkman/candidates/java/8.0.332-tem
-ENV JAVA_HOME_11=/home/user/.sdkman/candidates/java/11.0.15-tem
-ENV JAVA_HOME_17=/home/user/.sdkman/candidates/java/17.0.3-tem
+ENV JAVA_HOME_8=/home/tooling/.sdkman/candidates/java/8.0.332-tem
+ENV JAVA_HOME_11=/home/tooling/.sdkman/candidates/java/11.0.15-tem
+ENV JAVA_HOME_17=/home/tooling/.sdkman/candidates/java/17.0.3-tem
 
-# Java-related environment variables are described and set by /home/user/.bashrc
+# Java-related environment variables are described and set by /home/tooling/.bashrc
 # To make Java working for dash and other shells, it needs to initialize them in the Dockerfile.
 ENV SDKMAN_CANDIDATES_API="https://api.sdkman.io/2"
-ENV SDKMAN_CANDIDATES_DIR="/home/user/.sdkman/candidates"
-ENV SDKMAN_DIR="/home/user/.sdkman"
+ENV SDKMAN_CANDIDATES_DIR="/home/tooling/.sdkman/candidates"
+ENV SDKMAN_DIR="/home/tooling/.sdkman"
 ENV SDKMAN_PLATFORM="linuxx64"
 ENV SDKMAN_VERSION="5.13.0"
 
-ENV GRADLE_HOME="/home/user/.sdkman/candidates/gradle/current"
-ENV JAVA_HOME="/home/user/.sdkman/candidates/java/current"
-ENV MAVEN_HOME="/home/user/.sdkman/candidates/maven/current"
+ENV GRADLE_HOME="/home/tooling/.sdkman/candidates/gradle/current"
+ENV JAVA_HOME="/home/tooling/.sdkman/candidates/java/current"
+ENV MAVEN_HOME="/home/tooling/.sdkman/candidates/maven/current"
 
-ENV GRAALVM_HOME=/home/user/.sdkman/candidates/java/22.1.0.0.r17-mandrel
+ENV GRAALVM_HOME=/home/tooling/.sdkman/candidates/java/22.1.0.0.r17-mandrel
 
-ENV PATH="/home/user/.krew/bin:$PATH"
-ENV PATH="/home/user/.sdkman/candidates/maven/current/bin:$PATH"
-ENV PATH="/home/user/.sdkman/candidates/java/current/bin:$PATH"
-ENV PATH="/home/user/.sdkman/candidates/gradle/current/bin:$PATH"
-ENV PATH="/home/user/.local/share/coursier/bin:$PATH"
+ENV PATH="/home/tooling/.krew/bin:$PATH"
+ENV PATH="/home/tooling/.sdkman/candidates/maven/current/bin:$PATH"
+ENV PATH="/home/tooling/.sdkman/candidates/java/current/bin:$PATH"
+ENV PATH="/home/tooling/.sdkman/candidates/gradle/current/bin:$PATH"
+ENV PATH="/home/tooling/.local/share/coursier/bin:$PATH"
 
 # NodeJS
-ENV NVM_DIR="/home/user/.nvm"
+RUN mkdir -p /home/tooling/.nvm/
+ENV NVM_DIR="/home/tooling/.nvm"
 ENV NODEJS_20_VERSION=20.7.0
 # note that 18.18.0 is the latest but 18.16.1 is the supported version downstream and in ubi8
 ENV NODEJS_18_VERSION=18.16.1
 ENV NODEJS_DEFAULT_VERSION=${NODEJS_18_VERSION}
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | PROFILE=/dev/null bash
-RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/user/.bashrc \
-    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/user/.bashrc
-RUN source /home/user/.bashrc && \
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/tooling/.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/tooling/.bashrc
+RUN source /home/tooling/.bashrc && \
     nvm install v${NODEJS_20_VERSION} && \
     nvm install v${NODEJS_18_VERSION} && \
     nvm alias default v${NODEJS_DEFAULT_VERSION} && nvm use v${NODEJS_DEFAULT_VERSION} && \
     npm install --global yarn@v1.22.17 &&\
-    chgrp -R 0 /home/user && chmod -R g=u /home/user
+    chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
 ENV PATH=$NVM_DIR/versions/node/v${NODEJS_DEFAULT_VERSION}/bin:$PATH
 ENV NODEJS_HOME_20=$NVM_DIR/versions/node/v${NODEJS_20_VERSION}
 ENV NODEJS_HOME_18=$NVM_DIR/versions/node/v${NODEJS_18_VERSION}
 
 # kube
+# The Che User Dashboard creates the kube config in /home/user/ and not /home/tooling/
 ENV KUBECONFIG=/home/user/.kube/config
 
 USER 0
@@ -112,11 +122,11 @@ RUN curl -fLo mill https://raw.githubusercontent.com/lefou/millw/main/millw && \
 RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra gdb
 
 # Go 1.18+    - installed to /usr/bin/go
-# gopls 0.10+ - installed to /home/user/go/bin/gopls and /home/user/go/pkg/mod/
+# gopls 0.10+ - installed to /home/tooling/go/bin/gopls and /home/tooling/go/pkg/mod/
 RUN dnf install -y go-toolset && \
     GO111MODULE=on go install -v golang.org/x/tools/gopls@latest && \
-    chgrp -R 0 /home/user && chmod -R g=u /home/user
-ENV GOBIN="/home/user/go/bin/"
+    chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
+ENV GOBIN="/home/tooling/go/bin/"
 ENV PATH="$GOBIN:$PATH"
 
 # Python
@@ -159,14 +169,14 @@ ENV DOTNET_RPM_VERSION=6.0
 RUN dnf install -y dotnet-hostfxr-${DOTNET_RPM_VERSION} dotnet-runtime-${DOTNET_RPM_VERSION} dotnet-sdk-${DOTNET_RPM_VERSION}
 
 # rust
-ENV CARGO_HOME=/home/user/.cargo \
-    RUSTUP_HOME=/home/user/.rustup \
-    PATH=/home/user/.cargo/bin:${PATH}
+ENV CARGO_HOME=/home/tooling/.cargo \
+    RUSTUP_HOME=/home/tooling/.rustup \
+    PATH=/home/tooling/.cargo/bin:${PATH}
 RUN curl --proto '=https' --tlsv1.2 -sSfo rustup https://sh.rustup.rs && \
     chmod +x rustup && \
     mv rustup /usr/bin/ && \
     rustup -y --no-modify-path --profile minimal -c rust-src -c rust-analysis -c rls && \
-    chgrp -R 0 /home/user && chmod -R g=u /home/user
+    chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
 
 # camel-k
 ENV KAMEL_VERSION 1.11.0
@@ -233,7 +243,7 @@ EOF2
 
 dnf install -y kubectl
 curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
-echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/user/.bashrc
+echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/tooling/.bashrc
 EOF
 
 ## shellcheck
@@ -273,7 +283,7 @@ sha256sum -c "${KREW_TGZ}.sha256" 2>&1 | grep OK
 
 tar -zxvf "${KREW_TGZ}"
 ./"krew-${KREW_ARCH}" install krew
-echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> /home/user/.bashrc
+echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> /home/tooling/.bashrc
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 # kubens and kubectx
 kubectl krew install ns
@@ -414,7 +424,7 @@ RUN dnf -y install bash-completion \
     && rm -rf /var/cache/yum
 
 RUN <<EOF
-echo "source /etc/profile.d/bash_completion.sh" >> /home/user/.bashrc
+echo "source /etc/profile.d/bash_completion.sh" >> /home/tooling/.bashrc
 oc completion bash > /usr/share/bash-completion/completions/oc 
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
@@ -422,11 +432,18 @@ EOF
 
 # Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
 # NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly
-RUN echo 'export SDKMAN_DIR="/home/user/.sdkman"' >> /home/user/.bashrc
-RUN echo '[[ -s "/home/user/.sdkman/bin/sdkman-init.sh" ]] && source "/home/user/.sdkman/bin/sdkman-init.sh"' >> /home/user/.bashrc
+RUN echo 'export SDKMAN_DIR="/home/tooling/.sdkman"' >> /home/tooling/.bashrc
+RUN echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"' >> /home/tooling/.bashrc
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
+
+# Create symbolic links from /home/tooling/ -> /home/user/
+RUN dnf -y install stow \
+    && dnf clean all \
+    && rm -rf /var/cache/yum \
+    &&  stow . -t /home/user/ -d /home/tooling/ --no-folding
+
 
 # cleanup dnf cache
 RUN dnf -y clean all --enablerepo='*'
@@ -434,3 +451,5 @@ RUN dnf -y clean all --enablerepo='*'
 COPY --chown=0:0 entrypoint.sh /
 
 USER 10001
+
+ENV HOME=/home/user

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -17,6 +17,12 @@ LABEL description="Image with developers tools. Languages SDK and runtimes inclu
 LABEL io.k8s.display-name="devfile-developer-universal"
 LABEL io.openshift.expose-services=""
 
+USER 0
+
+# $PROFILE_EXT contains all additions made to the bash environment
+ENV PROFILE_EXT=/etc/profile.d/udi_environment.sh
+RUN touch ${PROFILE_EXT} & chown 10001 ${PROFILE_EXT}
+
 USER 10001
 
 # We install everything to /home/tooling/ as /home/user/ may get overriden, see github.com/eclipse/che/issues/22412
@@ -44,7 +50,7 @@ ENV JAVA_HOME_8=/home/tooling/.sdkman/candidates/java/8.0.332-tem
 ENV JAVA_HOME_11=/home/tooling/.sdkman/candidates/java/11.0.15-tem
 ENV JAVA_HOME_17=/home/tooling/.sdkman/candidates/java/17.0.3-tem
 
-# Java-related environment variables are described and set by /home/tooling/.bashrc
+# Java-related environment variables are described and set by ${PROFILE_EXT}, which will be loaded by ~/.bashrc
 # To make Java working for dash and other shells, it needs to initialize them in the Dockerfile.
 ENV SDKMAN_CANDIDATES_API="https://api.sdkman.io/2"
 ENV SDKMAN_CANDIDATES_DIR="/home/tooling/.sdkman/candidates"
@@ -72,9 +78,9 @@ ENV NODEJS_20_VERSION=20.7.0
 ENV NODEJS_18_VERSION=18.16.1
 ENV NODEJS_DEFAULT_VERSION=${NODEJS_18_VERSION}
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | PROFILE=/dev/null bash
-RUN echo 'export NVM_DIR="$HOME/.nvm"' >> /home/tooling/.bashrc \
-    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /home/tooling/.bashrc
-RUN source /home/tooling/.bashrc && \
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> ${PROFILE_EXT} \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ${PROFILE_EXT}
+RUN source /home/user/.bashrc && \
     nvm install v${NODEJS_20_VERSION} && \
     nvm install v${NODEJS_18_VERSION} && \
     nvm alias default v${NODEJS_DEFAULT_VERSION} && nvm use v${NODEJS_DEFAULT_VERSION} && \
@@ -190,7 +196,7 @@ RUN dnf -y module enable container-tools:rhel8 && \
     dnf -y update && \
     dnf -y reinstall shadow-utils && \
     dnf -y install podman buildah skopeo fuse-overlayfs
-RUN echo 'alias docker=podman' >> /home/user/.bashrc
+RUN echo 'alias docker=podman' >> ${PROFILE_EXT}
 
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to
@@ -238,7 +244,7 @@ EOF2
 
 dnf install -y kubectl
 curl -sSL -o ~/.kubectl_aliases https://raw.githubusercontent.com/ahmetb/kubectl-alias/master/.kubectl_aliases
-echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> /home/tooling/.bashrc
+echo '[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases' >> ${PROFILE_EXT}
 EOF
 
 ## shellcheck
@@ -278,7 +284,7 @@ sha256sum -c "${KREW_TGZ}.sha256" 2>&1 | grep OK
 
 tar -zxvf "${KREW_TGZ}"
 ./"krew-${KREW_ARCH}" install krew
-echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> /home/tooling/.bashrc
+echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> ${PROFILE_EXT}
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 # kubens and kubectx
 kubectl krew install ns
@@ -419,16 +425,15 @@ RUN dnf -y install bash-completion \
     && rm -rf /var/cache/yum
 
 RUN <<EOF
-echo "source /etc/profile.d/bash_completion.sh" >> /home/tooling/.bashrc
 oc completion bash > /usr/share/bash-completion/completions/oc 
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
 EOF
 
-# Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
-# NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly
-RUN echo 'export SDKMAN_DIR="/home/tooling/.sdkman"' >> /home/tooling/.bashrc
-RUN echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"' >> /home/tooling/.bashrc
+## Add sdkman's init script launcher to the end of ${PROFILE_EXT} since we are not adding it on sdkman install
+## NOTE: all modifications to ${PROFILE_EXT} must happen BEFORE this step in order for sdkman to function correctly
+RUN echo 'export SDKMAN_DIR="/home/tooling/.sdkman"' >> ${PROFILE_EXT}
+RUN echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"' >> ${PROFILE_EXT}
 
 
 # Create symbolic links from /home/tooling/ -> /home/user/

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -20,12 +20,7 @@ LABEL io.openshift.expose-services=""
 USER 10001
 
 # We install everything to /home/tooling/ as /home/user/ may get overriden, see github.com/eclipse/che/issues/22412
-RUN mkdir -p /home/tooling/
 ENV HOME=/home/tooling
-
-RUN cp /home/user/.bashrc /home/tooling/.bashrc
-# /home/user/.bashrc will be replaced with the a symlink from /home/tooling/.bashrc
-RUN rm /home/user/.bashrc    
 
 # Java
 RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
@@ -439,10 +434,7 @@ RUN echo '[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/s
 RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
 
 # Create symbolic links from /home/tooling/ -> /home/user/
-RUN dnf -y install stow \
-    && dnf clean all \
-    && rm -rf /var/cache/yum \
-    &&  stow . -t /home/user/ -d /home/tooling/ --no-folding
+RUN stow . -t /home/user/ -d /home/tooling/ --no-folding
 
 
 # cleanup dnf cache

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -20,7 +20,7 @@ LABEL io.openshift.expose-services=""
 USER 10001
 
 # Java
-RUN curl -fsSL "https://get.sdkman.io" | bash \
+RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
     && bash -c ". /home/user/.sdkman/bin/sdkman-init.sh \
              && sed -i "s/sdkman_auto_answer=false/sdkman_auto_answer=true/g" /home/user/.sdkman/etc/config \
 	     && sed -i "s/sdkman_auto_env=false/sdkman_auto_env=true/g" /home/user/.sdkman/etc/config \
@@ -413,6 +413,12 @@ make install-libs
 cd -
 rm -rf "${TEMP_DIR}"
 EOF
+
+
+# Add sdkman's init script launcher to the end of the .bashrc since we are not adding it on sdkman install
+# NOTE: all modifications to the .bashrc must happen BEFORE this step in order for sdkman to function correctly
+RUN echo 'export SDKMAN_DIR="/home/user/.sdkman"' >> /home/user/.bashrc
+RUN echo '[[ -s "/home/user/.sdkman/bin/sdkman-init.sh" ]] && source "/home/user/.sdkman/bin/sdkman-init.sh"' >> /home/user/.bashrc
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -20,7 +20,7 @@ if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
 
     echo "Starting kubedock with params \"${KUBEDOCK_PARAMS}\"..."
     
-    kubedock server "${KUBEDOCK_PARAMS}" > /tmp/kubedock.log 2>&1 &
+    kubedock server ${KUBEDOCK_PARAMS} > /tmp/kubedock.log 2>&1 &
     
     echo "Done."
 

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -62,6 +62,10 @@ if [ $HOME_USER_MOUNTED -eq 0 ] && [ ! -f $STOW_COMPLETE ]; then
     stow . -t /home/user/ -d /home/tooling/ --no-folding -v 2 > /tmp/stow.log 2>&1
     # Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it
     cp /home/tooling/.viminfo /home/user/.viminfo
+    # We have to restore bash-related files back onto /home/user/ (since they will have been overwritten by the PVC)
+    # but we don't want them to be symbolic links (so that they persist on the PVC)
+    cp /home/tooling/.bashrc /home/user/.bashrc
+    cp /home/tooling/.bash_profile /home/user/.bash_profile
     touch $STOW_COMPLETE
 fi
 

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# /home/user/ will be mounted to by a PVC if persistUserHome is enabled
+if mountpoint -q /home/user/; then
+    # Create symbolic links from /home/tooling/ -> /home/user/
+    stow . -t /home/user/ -d /home/tooling/ --no-folding
+fi
+
 # Kubedock
 if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
     echo

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -4,6 +4,8 @@
 if mountpoint -q /home/user/; then
     # Create symbolic links from /home/tooling/ -> /home/user/
     stow . -t /home/user/ -d /home/tooling/ --no-folding
+    # A symbolic link for .viminfo is not created for security reasons, so manually copy it
+    cp /home/tooling/.viminfo /home/user/.viminfo
 fi
 
 # Kubedock

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -8,31 +8,36 @@ if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
     SECONDS=0
     until [ -f $KUBECONFIG ]; do
         if (( SECONDS > 10 )); then
-            echo "Giving up..."
-            exit 1
+            break 
         fi
         echo "Kubeconfig doesn't exist yet. Waiting..."
         sleep 1
     done
-    echo "Kubeconfig found."
 
-    KUBEDOCK_PARAMS=${KUBEDOCK_PARAMS:-"--reverse-proxy --kubeconfig $KUBECONFIG"}
+    if [ -f $KUBECONFIG ]; then 
+        echo "Kubeconfig found."
 
-    echo "Starting kubedock with params \"${KUBEDOCK_PARAMS}\"..."
-    
-    kubedock server ${KUBEDOCK_PARAMS} > /tmp/kubedock.log 2>&1 &
-    
-    echo "Done."
+        KUBEDOCK_PARAMS=${KUBEDOCK_PARAMS:-"--reverse-proxy --kubeconfig $KUBECONFIG"}
 
-    echo "Replacing podman with podman-wrapper..."
+        echo "Starting kubedock with params \"${KUBEDOCK_PARAMS}\"..."
+        
+        kubedock server ${KUBEDOCK_PARAMS} > /tmp/kubedock.log 2>&1 &
+        
+        echo "Done."
 
-    ln -f -s /usr/bin/podman.wrapper /home/tooling/.local/bin/podman
+        echo "Replacing podman with podman-wrapper..."
 
-    export TESTCONTAINERS_RYUK_DISABLED="true"
-    export TESTCONTAINERS_CHECKS_DISABLE="true"
+        ln -f -s /usr/bin/podman.wrapper /home/tooling/.local/bin/podman
 
-    echo "Done."
-    echo
+        export TESTCONTAINERS_RYUK_DISABLED="true"
+        export TESTCONTAINERS_CHECKS_DISABLE="true"
+
+        echo "Done."
+        echo
+    else 
+        echo "Could not find Kubeconfig at $KUBECONFIG"
+        echo "Giving up..."
+    fi
 else
     echo
     echo "Kubedock is disabled. It can be enabled with the env variable \"KUBEDOCK_ENABLED=true\""

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -47,12 +47,22 @@ else
     ln -f -s /usr/bin/podman.orig /home/tooling/.local/bin/podman
 fi
 
+
+# Stow
+## Required for https://github.com/eclipse/che/issues/22412
+
 # /home/user/ will be mounted to by a PVC if persistUserHome is enabled
-if mountpoint -q /home/user/; then
+mountpoint -q /home/user/; HOME_USER_MOUNTED=$?
+
+# This file will be created after stowing, to guard from executing stow everytime the container is started
+STOW_COMPLETE=/home/user/.stow_completed
+
+if [ $HOME_USER_MOUNTED -eq 0 ] && [ ! -f $STOW_COMPLETE ]; then
     # Create symbolic links from /home/tooling/ -> /home/user/
     stow . -t /home/user/ -d /home/tooling/ --no-folding -v 2 > /tmp/stow.log 2>&1
     # Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it
     cp /home/tooling/.viminfo /home/user/.viminfo
+    touch $STOW_COMPLETE
 fi
 
 exec "$@"

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -50,7 +50,7 @@ fi
 # /home/user/ will be mounted to by a PVC if persistUserHome is enabled
 if mountpoint -q /home/user/; then
     # Create symbolic links from /home/tooling/ -> /home/user/
-    stow . -t /home/user/ -d /home/tooling/ --no-folding
+    stow . -t /home/user/ -d /home/tooling/ --no-folding -v 2 > /tmp/stow.log 2>&1
     # Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it
     cp /home/tooling/.viminfo /home/user/.viminfo
 fi

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -6,8 +6,9 @@ if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
     echo "Kubedock is enabled (env variable KUBEDOCK_ENABLED is set to true)."
 
     SECONDS=0
+    KUBEDOCK_TIMEOUT=${KUBEDOCK_TIMEOUT:-10}
     until [ -f $KUBECONFIG ]; do
-        if (( SECONDS > 10 )); then
+        if (( SECONDS > KUBEDOCK_TIMEOUT )); then
             break 
         fi
         echo "Kubeconfig doesn't exist yet. Waiting..."


### PR DESCRIPTION
This PR aims to resolve https://github.com/eclipse/che/issues/22412, where enabling `devEnvironments.persistUserHome` in the Che Cluster CR will cause the workspace's PVC to mount to `/home/user/`, overwriting any tools, configurations, etc. that are present in the UDI's  `/home/user/` directory.

In order to resolve this issue, we are now installing tools (and most config files) to `/home/tooling/` and using GNU stow to create symbolic links to `/home/user/` for all files in `/home/tooling/` (with the exception of `.viminfo`, which cannot be a symbolic link by vim's design). 

Rather than trying to keep `$PATH` to be exactly the same as prior to this change (i.e. tooling binaries are found in `/home/user/`) , `$PATH` has been modified to contain the appropriate directories in `/home/tooling/`. The reasoning for this change is due to the fact that the call to stow in the entrypoint is [not guaranteed](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) to run before any postStart commands. In order to ensure postStart commands can invoke all UDI binaries, they must be placed under `/home/tooling/`, which guarantees they will not be overwritten when a PVC is mounted to /home/user/.

Below are some other details regarding the changes made in this PR:

1. Stow is invoked with the  `--no-folding` option to recreate the directory tree structure from `/home/tooling/` in `/home/user/`, to ensure any changes within a configuration folder will persist on the PVC (as directories in `/home/tooling/` are essentially ephemeral). 
2. Stow is invoked up to 3 times: 
   - Once in the UBI8 base image, where the `--no-folding` option is not used due to the lack of directories in the /home/tooling/ of the base image.
   - Once in the UDI, with `--no-folding` enabled.
   - Once in the UDI's entrypoint, if we detect that `/home/user/` has been mounted by a PVC (erasing the contents of `/home/user/`)
3. Stow does _not_ create a symbolic link for `.viminfo`, as it [must be a regular file by vim's design](https://github.com/vim/vim/issues/2506#issuecomment-1154341891). Consequently, the `.viminfo` must be manually copied from `/home/tooling/` -> `/home/user/`.
4. Stow adds a bit of extra startup time to the container when it is invoked in the UDI's entrypoint . Unfortunately, we cannot run it as a background process or else it [might not complete successfully when the container is started](https://github.com/devfile/developer-images/pull/115#issuecomment-1714761293).
5. The changes from https://github.com/devfile/developer-images/pull/117 were adopted for this PR. I kept `/home/user/.local/bin/` still on `$PATH` so that users could mount their own binaries to `/home/user/.local/bin/` and invoke them as VSCode tasks or postStart commands. 
6. `$SDKMAN_DIR` and `$NVM_DIR` are hard-coded to point to `/home/tooling/.sdkman` (rather than `$HOME/.sdkman`). sdkman will not function if `$SDKMAN_DIR` is set to `/home/user/.sdkman/`, as its init script [won't detect symlinks](https://github.com/sdkman/sdkman-cli/blob/master/src/main/bash/sdkman-init.sh#L75).
7. We are no longer modifying the `~/.bashrc` to extend the bash environment. Instead, we now have 2 bash scripts located in `/etc/profile.d/`: one which modifies the bash environment, another to set the terminal prompt. These scripts are automatically loaded by bash. Now, users are free to modify the UDI's .bashrc (e.g. overwritting it with an automount configmap in Che) without breaking any modifications to `$PATH` that we provide in the UDI (such as sdkman).
8. I removed code from the UBI8's entrypoint that involved manually creating a `~/.bashrc`, [which was obsolete](https://github.com/devfile/developer-images/pull/115#issuecomment-1726996106).
9. The entrypoint now looks for the kubeconfig in `$KUBECONFIG` rather than being hard-coded to `/home/user/.kube/config`.
10. The kubedock entrypoint was modified to no longer fail if the kube config could not be found.
11. The duration of the timeout for finding the kube config in the entrypoint can now be changed with `$KUBEDOCK_TIMEOUT`

This PR is also based off of https://github.com/devfile/developer-images/pull/110, so reading the changes introduced in that PR is also worthwhile. 

## Testing
I've pushed `quay.io/aobuchow/universal-developer-image:stow` to test the UDI as a docker container. I've also created a sample [devfile](https://github.com/AObuchow/udi-tooling/blob/master/devfile.yaml) that uses the updated UDI, to test in Che with `devEnvironments.persistUserHome.enabled: true`.

### Sample devfile notes
My sample devfile [invokes some commands](https://github.com/AObuchow/udi-tooling/blob/master/devfile.yaml#L63) to ensure they are available on $PATH to run as preStart commands. Note: some of these commands generate stderr output, which can be viewed in `/tmp/poststart-stderr.txt`.

Additionally, I attempted to [log the binaries available as postStart commands](https://github.com/AObuchow/udi-tooling/blob/master/devfile.yaml#L65-L69) with `compgen -c | xargs which --all --skip-functions | sort | uniq > /projects/udi-tooling/binaries.txt ; ` [Here's the output of that command](https://github.com/AObuchow/udi-tooling/blob/master/binaries.txt).

One final note about my devfile: since postStart commands in DWO are run as `/bin/sh -C { <commands> }` any modifications to `$PATH` present in the bash environment are normally not usable (e.g. nvm cannot be invoked). To workaround this, I added a postStart command that runs source `/home/user/.bashrc` in the parent devfile. This workaround could potentially be used in CheCode when running VSCode tasks ([relevant comment](https://github.com/devfile/developer-images/pull/113#issuecomment-1710612441)). 

### Other testing notes

Properly ensuring this PR does not break any existing functionality or workflows may be tricky due to the nature of moving everything out of `/home/user/` into `/home/tooling/` (and then "back" into `/home/user/` with stow).

Since the podman wrapper was affected by this change, it's also worth ensuring the test cases ([wrapped podman commands](https://github.com/devfile/developer-images/pull/107/files#diff-22935aa66ea1760572f5547f38f94faf4abd071e88a5a33f6a92e139f79cb54dR5)) from https://github.com/devfile/developer-images/pull/107 work as well. 

Below are some comparisons of the `/home/user/` directory, the `/home/user/.bashrc` and `$PATH`, before and after this change. 

### `ls -la` in `/home/user/` directory
#### Before:

```bash
~ $ ls -la
total 108
drwxrwx---. 1 user root   244 Aug 29 02:12 .
drwxrwxr-x. 1 root root     8 Jul 17 19:51 ..
-rw-rw-r--. 1 user root    18 Jun 20  2022 .bash_logout
-rw-rw-r--. 1 user root   141 Jun 20  2022 .bash_profile
-rw-rw-r--. 1 user root   826 Aug  3 17:34 .bashrc
drwxrwxr-x. 1 root root    22 Aug  3 17:30 .cache
drwxrwxr-x. 1 root root    12 Aug  3 17:31 .cargo
drwxrwxr-x. 1 root root    36 Aug  3 17:33 .config
-rw-rw-r--. 1 root root   126 Jul 17 19:51 .gitconfig
drwxrwxr-x. 1 root root    42 Aug  3 17:33 .krew
-rw-rw-r--. 1 root root 88043 Aug  3 17:33 .kubectl_aliases
drwxr-xr-x. 1 user user     6 Aug 29 02:12 .local
drwxrwxr-x. 1 user root    84 Aug  3 17:27 .npm
drwxrwxr-x. 1 user root   610 Aug  3 17:27 .nvm
drwxrwxr-x. 1 root root    96 Aug  3 17:31 .rustup
drwxrwxr-x. 1 user root    84 Aug  3 04:47 .sdkman
-rw-rw-r--. 1 root root   172 Aug  3 17:28 .wget-hsts
drwxrwxr-x. 1 root root    12 Aug  3 17:30 go
```
#### After:
```bash
~ $ ls -la
total 28
drwxrwx---. 1 user root 260 Sep 20 04:28 .
drwxrwxr-x. 1 root root  22 Sep 20 04:07 ..
-rw-rw-r--. 1 user root  18 Jun 20  2022 .bash_logout
-rw-rw-r--. 1 user root 141 Jun 20  2022 .bash_profile
-rw-rw-r--. 1 user root 376 Jun 20  2022 .bashrc
drwxrwxr-x. 1 root root  22 Sep 20 04:28 .cache
drwxrwxr-x. 1 root root  12 Sep 20 04:28 .cargo
drwxrwxr-x. 1 root root  36 Sep 20 04:28 .config
lrwxrwxrwx. 1 root root  21 Sep 20 04:07 .gitconfig -> ../tooling/.gitconfig
drwxrwxr-x. 1 root root  42 Sep 20 04:28 .krew
lrwxrwxrwx. 1 root root  27 Sep 20 04:28 .kubectl_aliases -> ../tooling/.kubectl_aliases
drwxrwxr-x. 1 root root   6 Sep 20 04:28 .local
drwxrwxr-x. 1 root root  84 Sep 20 04:28 .npm
drwxrwxr-x. 1 root root 610 Sep 20 04:28 .nvm
drwxrwxr-x. 1 root root  96 Sep 20 04:28 .rustup
drwxrwxr-x. 1 root root  84 Sep 20 04:28 .sdkman
-rw-rw----. 1 root root 532 Sep 20 04:07 .viminfo
lrwxrwxrwx. 1 root root  21 Sep 20 04:28 .wget-hsts -> ../tooling/.wget-hsts
drwxrwxr-x. 1 root root  12 Sep 20 04:28 go
```
### `/home/user/` directory tree

Directory tree created using https://github.com/a8m/tree/tree/master: installed by running `go install github.com/a8m/tree/cmd/tree@latest` then `go clean -cache`

#### Before:
```bash
.
├── .bash_logout
├── .bash_profile
├── .bashrc
├── .cache
│   ├── go-build
│   │   ├── README
│   │   └── trim.txt
│   └── pip
│       ├── http
│       └── selfcheck
├── .cargo
│   ├── bin
│   │   ├── cargo
│   │   ├── cargo-clippy
│   │   ├── cargo-fmt
│   │   ├── cargo-miri
│   │   ├── clippy-driver
│   │   ├── rls
│   │   ├── rust-analyzer
│   │   ├── rust-gdb
│   │   ├── rust-gdbgui
│   │   ├── rust-lldb
│   │   ├── rustc
│   │   ├── rustdoc
│   │   ├── rustfmt
│   │   └── rustup
│   └── env
├── .config
│   ├── composer
│   │   ├── keys.dev.pub
│   │   └── keys.tags.pub
│   └── containers
│       └── storage.conf
├── .gitconfig
├── .krew
│   ├── bin
│   │   ├── kubectl-ctx -> /home/user/.krew/store/ctx/v0.9.5/kubectx
│   │   ├── kubectl-krew -> /home/user/.krew/store/krew/v0.4.4/krew
│   │   └── kubectl-ns -> /home/user/.krew/store/ns/v0.9.5/kubens
│   ├── index
│   │   └── default
│   ├── receipts
│   │   ├── ctx.yaml
│   │   ├── krew.yaml
│   │   └── ns.yaml
│   └── store
│       ├── ctx
│       ├── krew
│       └── ns
├── .kubectl_aliases
├── .npm
│   ├── _cacache
│   │   ├── content-v2
│   │   ├── index-v5
│   │   └── tmp
│   ├── _logs
│   │   ├── 2023-07-17T19_53_43_861Z-debug-0.log
│   │   ├── 2023-07-17T19_53_48_751Z-debug-0.log
│   │   ├── 2023-07-17T19_53_49_051Z-debug-0.log
│   │   └── 2023-07-17T19_53_49_684Z-debug-0.log
│   └── _update-notifier-last-checked
├── .nvm
│   ├── .cache
│   │   └── bin
│   ├── .dockerignore
│   ├── .editorconfig
│   ├── .git
│   │   ├── FETCH_HEAD
│   │   ├── HEAD
│   │   ├── branches
│   │   ├── config
│   │   ├── description
│   │   ├── hooks
│   │   ├── index
│   │   ├── info
│   │   ├── logs
│   │   ├── objects
│   │   ├── packed-refs
│   │   ├── refs
│   │   └── shallow
│   ├── .gitattributes
│   ├── .github
│   │   ├── FUNDING.yml
│   │   ├── ISSUE_TEMPLATE.md
│   │   ├── SECURITY.md
│   │   └── workflows
│   ├── .gitignore
│   ├── .mailmap
│   ├── .npmrc
│   ├── .travis.yml
│   ├── CODE_OF_CONDUCT.md
│   ├── CONTRIBUTING.md
│   ├── Dockerfile
│   ├── GOVERNANCE.md
│   ├── LICENSE.md
│   ├── Makefile
│   ├── PROJECT_CHARTER.md
│   ├── README.md
│   ├── ROADMAP.md
│   ├── alias
│   │   ├── default
│   │   └── lts
│   ├── bash_completion
│   ├── install.sh
│   ├── nvm-exec
│   ├── nvm.sh
│   ├── package.json
│   ├── rename_test.sh
│   ├── test
│   │   ├── common.sh
│   │   ├── fast
│   │   ├── install_script
│   │   ├── installation_iojs
│   │   ├── installation_node
│   │   ├── mocks
│   │   ├── slow
│   │   └── sourcing
│   ├── update_test_mocks.sh
│   └── versions
│       └── node
├── .rustup
│   ├── downloads
│   ├── settings.toml
│   ├── tmp
│   ├── toolchains
│   │   └── stable-x86_64-unknown-linux-gnu
│   └── update-hashes
│       └── stable-x86_64-unknown-linux-gnu
├── .sdkman
│   ├── bin
│   │   └── sdkman-init.sh
│   ├── candidates
│   │   ├── gradle
│   │   ├── java
│   │   ├── jbang
│   │   └── maven
│   ├── contrib
│   │   └── completion
│   ├── etc
│   │   └── config
│   ├── ext
│   ├── libexec
│   │   ├── default
│   │   ├── help
│   │   ├── home
│   │   ├── uninstall
│   │   └── version
│   ├── src
│   │   ├── sdkman-availability.sh
│   │   ├── sdkman-cache.sh
│   │   ├── sdkman-config.sh
│   │   ├── sdkman-current.sh
│   │   ├── sdkman-default.sh
│   │   ├── sdkman-env-helpers.sh
│   │   ├── sdkman-env.sh
│   │   ├── sdkman-flush.sh
│   │   ├── sdkman-help.sh
│   │   ├── sdkman-home.sh
│   │   ├── sdkman-install.sh
│   │   ├── sdkman-list.sh
│   │   ├── sdkman-main.sh
│   │   ├── sdkman-offline.sh
│   │   ├── sdkman-path-helpers.sh
│   │   ├── sdkman-selfupdate.sh
│   │   ├── sdkman-uninstall.sh
│   │   ├── sdkman-update.sh
│   │   ├── sdkman-upgrade.sh
│   │   ├── sdkman-use.sh
│   │   ├── sdkman-utils.sh
│   │   └── sdkman-version.sh
│   ├── tmp
│   └── var
│       ├── candidates
│       ├── delay_upgrade
│       ├── metadata
│       ├── platform
│       ├── version
│       └── version_native
├── .wget-hsts
├── .zshrc
└── go
    ├── bin
    │   ├── gopls
    │   └── tree
    └── pkg
        ├── mod
        └── sumdb

76 directories, 111 files
```

#### After:

```bash
~ $ tree -l -a
.
├── .bash_logout
├── .bash_profile
├── .bashrc
├── .cache
│   ├── go-build
│   │   ├── README -> ../../../tooling/.cache/go-build/README
│   │   └── trim.txt -> ../../../tooling/.cache/go-build/trim.txt
│   └── pip
│       ├── http
│       └── selfcheck
├── .cargo
│   ├── bin
│   │   ├── cargo -> ../../../tooling/.cargo/bin/cargo
│   │   ├── cargo-clippy -> ../../../tooling/.cargo/bin/cargo-clippy
│   │   ├── cargo-fmt -> ../../../tooling/.cargo/bin/cargo-fmt
│   │   ├── cargo-miri -> ../../../tooling/.cargo/bin/cargo-miri
│   │   ├── clippy-driver -> ../../../tooling/.cargo/bin/clippy-driver
│   │   ├── rls -> ../../../tooling/.cargo/bin/rls
│   │   ├── rust-analyzer -> ../../../tooling/.cargo/bin/rust-analyzer
│   │   ├── rust-gdb -> ../../../tooling/.cargo/bin/rust-gdb
│   │   ├── rust-gdbgui -> ../../../tooling/.cargo/bin/rust-gdbgui
│   │   ├── rust-lldb -> ../../../tooling/.cargo/bin/rust-lldb
│   │   ├── rustc -> ../../../tooling/.cargo/bin/rustc
│   │   ├── rustdoc -> ../../../tooling/.cargo/bin/rustdoc
│   │   ├── rustfmt -> ../../../tooling/.cargo/bin/rustfmt
│   │   └── rustup -> ../../../tooling/.cargo/bin/rustup
│   └── env -> ../../tooling/.cargo/env
├── .config
│   ├── composer
│   │   ├── keys.dev.pub -> ../../../tooling/.config/composer/keys.dev.pub
│   │   └── keys.tags.pub -> ../../../tooling/.config/composer/keys.tags.pub
│   └── containers
│       └── storage.conf -> ../../../tooling/.config/containers/storage.conf
├── .gitconfig -> ../tooling/.gitconfig
├── .krew
│   ├── bin
│   │   ├── kubectl-ctx -> ../../../tooling/.krew/bin/kubectl-ctx
│   │   ├── kubectl-krew -> ../../../tooling/.krew/bin/kubectl-krew
│   │   └── kubectl-ns -> ../../../tooling/.krew/bin/kubectl-ns
│   ├── index
│   │   └── default
│   ├── receipts
│   │   ├── ctx.yaml -> ../../../tooling/.krew/receipts/ctx.yaml
│   │   ├── krew.yaml -> ../../../tooling/.krew/receipts/krew.yaml
│   │   └── ns.yaml -> ../../../tooling/.krew/receipts/ns.yaml
│   └── store
│       ├── ctx
│       ├── krew
│       └── ns
├── .kubectl_aliases -> ../tooling/.kubectl_aliases
├── .local
│   └── bin
├── .npm
│   ├── _cacache
│   │   ├── content-v2
│   │   ├── index-v5
│   │   └── tmp
│   ├── _logs
│   │   ├── 2023-09-20T04_14_47_221Z-debug-0.log -> ../../../tooling/.npm/_logs/2023-09-20T04_14_47_221Z-debug-0.log
│   │   ├── 2023-09-20T04_15_31_306Z-debug-0.log -> ../../../tooling/.npm/_logs/2023-09-20T04_15_31_306Z-debug-0.log
│   │   ├── 2023-09-20T04_15_31_572Z-debug-0.log -> ../../../tooling/.npm/_logs/2023-09-20T04_15_31_572Z-debug-0.log
│   │   └── 2023-09-20T04_15_38_586Z-debug-0.log -> ../../../tooling/.npm/_logs/2023-09-20T04_15_38_586Z-debug-0.log
│   └── _update-notifier-last-checked -> ../../tooling/.npm/_update-notifier-last-checked
├── .nvm
│   ├── .cache
│   │   └── bin
│   ├── .dockerignore -> ../../tooling/.nvm/.dockerignore
│   ├── .editorconfig -> ../../tooling/.nvm/.editorconfig
│   ├── .git
│   │   ├── FETCH_HEAD -> ../../../tooling/.nvm/.git/FETCH_HEAD
│   │   ├── HEAD -> ../../../tooling/.nvm/.git/HEAD
│   │   ├── branches
│   │   ├── config -> ../../../tooling/.nvm/.git/config
│   │   ├── description -> ../../../tooling/.nvm/.git/description
│   │   ├── hooks
│   │   ├── index -> ../../../tooling/.nvm/.git/index
│   │   ├── info
│   │   ├── logs
│   │   ├── objects
│   │   ├── packed-refs -> ../../../tooling/.nvm/.git/packed-refs
│   │   ├── refs
│   │   └── shallow -> ../../../tooling/.nvm/.git/shallow
│   ├── .gitattributes -> ../../tooling/.nvm/.gitattributes
│   ├── .github
│   │   ├── FUNDING.yml -> ../../../tooling/.nvm/.github/FUNDING.yml
│   │   ├── ISSUE_TEMPLATE.md -> ../../../tooling/.nvm/.github/ISSUE_TEMPLATE.md
│   │   ├── SECURITY.md -> ../../../tooling/.nvm/.github/SECURITY.md
│   │   └── workflows
│   ├── .gitignore -> ../../tooling/.nvm/.gitignore
│   ├── .mailmap -> ../../tooling/.nvm/.mailmap
│   ├── .npmrc -> ../../tooling/.nvm/.npmrc
│   ├── .travis.yml -> ../../tooling/.nvm/.travis.yml
│   ├── CODE_OF_CONDUCT.md -> ../../tooling/.nvm/CODE_OF_CONDUCT.md
│   ├── CONTRIBUTING.md -> ../../tooling/.nvm/CONTRIBUTING.md
│   ├── Dockerfile -> ../../tooling/.nvm/Dockerfile
│   ├── GOVERNANCE.md -> ../../tooling/.nvm/GOVERNANCE.md
│   ├── LICENSE.md -> ../../tooling/.nvm/LICENSE.md
│   ├── Makefile -> ../../tooling/.nvm/Makefile
│   ├── PROJECT_CHARTER.md -> ../../tooling/.nvm/PROJECT_CHARTER.md
│   ├── README.md -> ../../tooling/.nvm/README.md
│   ├── ROADMAP.md -> ../../tooling/.nvm/ROADMAP.md
│   ├── alias
│   │   ├── default -> ../../../tooling/.nvm/alias/default
│   │   └── lts
│   ├── bash_completion -> ../../tooling/.nvm/bash_completion
│   ├── install.sh -> ../../tooling/.nvm/install.sh
│   ├── nvm-exec -> ../../tooling/.nvm/nvm-exec
│   ├── nvm.sh -> ../../tooling/.nvm/nvm.sh
│   ├── package.json -> ../../tooling/.nvm/package.json
│   ├── rename_test.sh -> ../../tooling/.nvm/rename_test.sh
│   ├── test
│   │   ├── common.sh -> ../../../tooling/.nvm/test/common.sh
│   │   ├── fast
│   │   ├── install_script
│   │   ├── installation_iojs
│   │   ├── installation_node
│   │   ├── mocks
│   │   ├── slow
│   │   └── sourcing
│   ├── update_test_mocks.sh -> ../../tooling/.nvm/update_test_mocks.sh
│   └── versions
│       └── node
├── .rustup
│   ├── downloads
│   ├── settings.toml -> ../../tooling/.rustup/settings.toml
│   ├── tmp
│   ├── toolchains
│   │   └── stable-x86_64-unknown-linux-gnu
│   └── update-hashes
│       └── stable-x86_64-unknown-linux-gnu -> ../../../tooling/.rustup/update-hashes/stable-x86_64-unknown-linux-gnu
├── .sdkman
│   ├── bin
│   │   └── sdkman-init.sh -> ../../../tooling/.sdkman/bin/sdkman-init.sh
│   ├── candidates
│   │   ├── gradle
│   │   ├── java
│   │   ├── jbang
│   │   └── maven
│   ├── contrib
│   │   └── completion
│   ├── etc
│   │   └── config -> ../../../tooling/.sdkman/etc/config
│   ├── ext
│   ├── libexec
│   │   ├── default -> ../../../tooling/.sdkman/libexec/default
│   │   ├── help -> ../../../tooling/.sdkman/libexec/help
│   │   ├── home -> ../../../tooling/.sdkman/libexec/home
│   │   ├── uninstall -> ../../../tooling/.sdkman/libexec/uninstall
│   │   └── version -> ../../../tooling/.sdkman/libexec/version
│   ├── src
│   │   ├── sdkman-availability.sh -> ../../../tooling/.sdkman/src/sdkman-availability.sh
│   │   ├── sdkman-cache.sh -> ../../../tooling/.sdkman/src/sdkman-cache.sh
│   │   ├── sdkman-config.sh -> ../../../tooling/.sdkman/src/sdkman-config.sh
│   │   ├── sdkman-current.sh -> ../../../tooling/.sdkman/src/sdkman-current.sh
│   │   ├── sdkman-default.sh -> ../../../tooling/.sdkman/src/sdkman-default.sh
│   │   ├── sdkman-env-helpers.sh -> ../../../tooling/.sdkman/src/sdkman-env-helpers.sh
│   │   ├── sdkman-env.sh -> ../../../tooling/.sdkman/src/sdkman-env.sh
│   │   ├── sdkman-flush.sh -> ../../../tooling/.sdkman/src/sdkman-flush.sh
│   │   ├── sdkman-help.sh -> ../../../tooling/.sdkman/src/sdkman-help.sh
│   │   ├── sdkman-home.sh -> ../../../tooling/.sdkman/src/sdkman-home.sh
│   │   ├── sdkman-install.sh -> ../../../tooling/.sdkman/src/sdkman-install.sh
│   │   ├── sdkman-list.sh -> ../../../tooling/.sdkman/src/sdkman-list.sh
│   │   ├── sdkman-main.sh -> ../../../tooling/.sdkman/src/sdkman-main.sh
│   │   ├── sdkman-offline.sh -> ../../../tooling/.sdkman/src/sdkman-offline.sh
│   │   ├── sdkman-path-helpers.sh -> ../../../tooling/.sdkman/src/sdkman-path-helpers.sh
│   │   ├── sdkman-selfupdate.sh -> ../../../tooling/.sdkman/src/sdkman-selfupdate.sh
│   │   ├── sdkman-uninstall.sh -> ../../../tooling/.sdkman/src/sdkman-uninstall.sh
│   │   ├── sdkman-update.sh -> ../../../tooling/.sdkman/src/sdkman-update.sh
│   │   ├── sdkman-upgrade.sh -> ../../../tooling/.sdkman/src/sdkman-upgrade.sh
│   │   ├── sdkman-use.sh -> ../../../tooling/.sdkman/src/sdkman-use.sh
│   │   ├── sdkman-utils.sh -> ../../../tooling/.sdkman/src/sdkman-utils.sh
│   │   └── sdkman-version.sh -> ../../../tooling/.sdkman/src/sdkman-version.sh
│   ├── tmp
│   └── var
│       ├── candidates -> ../../../tooling/.sdkman/var/candidates
│       ├── delay_upgrade -> ../../../tooling/.sdkman/var/delay_upgrade
│       ├── metadata
│       ├── platform -> ../../../tooling/.sdkman/var/platform
│       ├── version -> ../../../tooling/.sdkman/var/version
│       └── version_native -> ../../../tooling/.sdkman/var/version_native
├── .viminfo
├── .wget-hsts -> ../tooling/.wget-hsts
└── go
    ├── bin
    │   └── gopls -> ../../../tooling/go/bin/gopls
    └── pkg
        ├── mod
        └── sumdb

78 directories, 110 files
```


### .bashrc
#### Before:

```bash
~ $ cat /home/user/.bashrc
# .bashrc

# Source global definitions
if [ -f /etc/bashrc ]; then
        . /etc/bashrc
fi

# User specific environment
if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
then
    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
fi
export PATH

# Uncomment the following line if you don't like systemctl's auto-paging feature:
# export SYSTEMD_PAGER=

# User specific aliases and functions
export PS1='\W `git branch --show-current 2>/dev/null | sed -r -e "s@^(.+)@\(\1\) @"`$ '

#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
export SDKMAN_DIR="$HOME/.sdkman"
[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
source /usr/share/bash-completion/completions/git
source /usr/share/bash-completion/completions/oc
[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases
export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
```

#### After:

```bash
~ $ cat /home/user/.bashrc
# .bashrc

# Source global definitions
if [ -f /etc/bashrc ]; then
        . /etc/bashrc
fi

# User specific environment
if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
then
    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
fi
export PATH

# Uncomment the following line if you don't like systemctl's auto-paging feature:
# export SYSTEMD_PAGER=

# User specific aliases and functions
```

Also, here are the 2 new files in `/etc/profile.d/`:

```bash
profile.d $ cat udi_environment.sh 
export NVM_DIR="/home/tooling/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
[ -f ~/.kubectl_aliases ] && source ~/.kubectl_aliases
export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
export SDKMAN_DIR="/home/tooling/.sdkman"
[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"
```

```bash
profile.d $ cat udi_prompt.sh 
export PS1='\W `git branch --show-current 2>/dev/null | sed -r -e "s@^(.+)@\(\1\) @"`$ '
```


### $PATH
#### Before:

```
~ $ echo $PATH | tr : \\n | sort
/bin
/home/user/.cargo/bin
/home/user/.dotnet/tools
/home/user/.krew/bin
/home/user/.krew/bin
/home/user/.local/bin
/home/user/.local/share/coursier/bin
/home/user/.nvm/versions/node/v16.14.0/bin
/home/user/.sdkman/candidates/gradle/current/bin
/home/user/.sdkman/candidates/java/current/bin
/home/user/.sdkman/candidates/jbang/current/bin
/home/user/.sdkman/candidates/maven/current/bin
/home/user/bin
/home/user/go/bin/
/sbin
/usr/bin
/usr/local/bin
/usr/local/sbin
/usr/sbin
/usr/share/Modules/bin
```

#### After:

```
~ $ echo $PATH | tr : \\n | sort
/bin
/home/tooling/.cargo/bin
/home/tooling/.krew/bin
/home/tooling/.local/bin
/home/tooling/.local/share/coursier/bin
/home/tooling/.nvm/versions/node/v16.14.0/bin
/home/tooling/.sdkman/candidates/gradle/current/bin
/home/tooling/.sdkman/candidates/java/current/bin
/home/tooling/.sdkman/candidates/jbang/current/bin
/home/tooling/.sdkman/candidates/maven/current/bin
/home/tooling/go/bin/
/home/user/.dotnet/tools
/home/user/.krew/bin
/home/user/.local/bin
/home/user/.local/bin
/home/user/bin
/sbin
/usr/bin
/usr/local/bin
/usr/local/sbin
/usr/sbin
/usr/share/Modules/bin
```
