### PR TITLE
chore: Update how file permissions in /home/user are handled

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -97,6 +97,7 @@ RUN \
     # Copy the global git configuration to user config as global /etc/gitconfig
     #  file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig /home/user/.gitconfig && \
+    chown 10001 /home/user/.gitconfig && \
     # Set permissions on /etc/passwd and /home to allow arbitrary users to write
     chgrp -R 0 /home && \
     chmod -R g=u /etc/passwd /etc/group /home && \

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -33,7 +33,8 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
              && sdk install maven \
              && sdk install jbang \
              && sdk flush archives \
-             && sdk flush temp"
+             && sdk flush temp" \
+    && chgrp -R 0 /home/user && chmod -R g=u /home/user
 
 # sdk home java <version>
 ENV JAVA_HOME_8=/home/user/.sdkman/candidates/java/8.0.332-tem
@@ -65,8 +66,9 @@ ENV NVM_DIR="/home/user/.nvm"
 ENV NODEJS_VERSION=16.14.0
 ENV NODEJS_12_VERSION=12.22.10
 ENV NODEJS_14_VERSION=14.19.0
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-RUN source /home/user/.bashrc && nvm install v${NODEJS_VERSION} && nvm install v${NODEJS_14_VERSION} && nvm install v${NODEJS_12_VERSION} && nvm alias default v$NODEJS_VERSION && nvm use v$NODEJS_VERSION && npm install --global yarn@v1.22.17
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash &&\
+    source /home/user/.bashrc && nvm install v${NODEJS_VERSION} && nvm install v${NODEJS_14_VERSION} && nvm install v${NODEJS_12_VERSION} && nvm alias default v$NODEJS_VERSION && nvm use v$NODEJS_VERSION && npm install --global yarn@v1.22.17 &&\
+    chgrp -R 0 /home/user && chmod -R g=u /home/user
 ENV PATH=$NVM_DIR/versions/node/v$NODEJS_VERSION/bin:$PATH
 ENV NODEJS_HOME_12=$NVM_DIR/versions/node/v$NODEJS_12_VERSION
 ENV NODEJS_HOME_14=$NVM_DIR/versions/node/v$NODEJS_14_VERSION
@@ -94,14 +96,15 @@ RUN curl -fLo sbt https://raw.githubusercontent.com/dwijnand/sbt-extras/master/s
 RUN curl -fLo mill https://raw.githubusercontent.com/lefou/millw/main/millw && \
     chmod +x mill && \
     mv mill /usr/local/bin/
-    
+
 # C/CPP
 RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra gdb
 
 # Go 1.18+    - installed to /usr/bin/go
 # gopls 0.10+ - installed to /home/user/go/bin/gopls and /home/user/go/pkg/mod/
 RUN dnf install -y go-toolset && \
-    GO111MODULE=on go install -v golang.org/x/tools/gopls@latest
+    GO111MODULE=on go install -v golang.org/x/tools/gopls@latest && \
+    chgrp -R 0 /home/user && chmod -R g=u /home/user
 ENV GOBIN="/home/user/go/bin/"
 ENV PATH="$GOBIN:$PATH"
 
@@ -151,7 +154,8 @@ ENV CARGO_HOME=/home/user/.cargo \
 RUN curl --proto '=https' --tlsv1.2 -sSfo rustup https://sh.rustup.rs && \
     chmod +x rustup && \
     mv rustup /usr/bin/ && \
-    rustup -y --no-modify-path --profile minimal -c rust-src -c rust-analysis -c rls
+    rustup -y --no-modify-path --profile minimal -c rust-src -c rust-analysis -c rls && \
+    chgrp -R 0 /home/user && chmod -R g=u /home/user
 
 # camel-k
 ENV KAMEL_VERSION 1.11.0
@@ -171,7 +175,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSIO
     && echo "source /usr/share/bash-completion/completions/oc" >> /home/user/.bashrc
 
 ## podman buildah skopeo
-RUN dnf -y module enable container-tools:rhel8 && \ 
+RUN dnf -y module enable container-tools:rhel8 && \
     dnf -y update && \
     dnf -y reinstall shadow-utils && \
     dnf -y install podman buildah skopeo fuse-overlayfs
@@ -344,8 +348,8 @@ KN_CHEKSUMS_URL="https://github.com/knative/client/releases/download/v${KN_VERSI
 curl -sSLO "${KN_BIN_URL}"
 curl -sSLO "${KN_CHEKSUMS_URL}"
 sha256sum --ignore-missing -c "checksums.txt" 2>&1 | grep OK
-mv "${KN_BIN}" kn 
-chmod +x kn 
+mv "${KN_BIN}" kn
+chmod +x kn
 mv kn /usr/local/bin
 cd -
 rm -rf "${TEMP_DIR}"
@@ -365,7 +369,7 @@ curl -sSLO "${TF_ZIP_URL}"
 curl -sSLO "${TF_CHEKSUMS_URL}"
 sha256sum --ignore-missing -c "terraform_${TF_VERSION}_SHA256SUMS" 2>&1 | grep OK
 unzip ${TF_ZIP}
-chmod +x terraform 
+chmod +x terraform
 mv terraform /usr/local/bin
 cd -
 rm -rf "${TEMP_DIR}"


### PR DESCRIPTION
### Description
Update the universal developer image Dockerfile to run
```bash
chgrp -R 0 /home/user && chmod -R g=u /home/user
```
after every RUN step that impacts `/home/user` significantly. This has the effect of reducing the udi8 image's size from `9.34GB` to `6.59GB` (on disk) -- a ~30% decrease.

Previously, one of the last steps in the build process was
```
RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
```
executing `chgrp` and `chmod` on `/home` resulted in a new layer in the image with _all_ of the files in `/home` copied (due to the overlay filesystem). By setting permissions as we create files (i.e. in the same RUN command that creates them) we avoid this last step exploding image size:

* Before
    ```
    ❯ docker history quay.io/devfile/universal-developer-image:ubi8-latest | head -n 5    
    IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
    a6500150cb06   2 weeks ago   USER 10001                                      0B        buildkit.dockerfile.v0
    <missing>      2 weeks ago   COPY entrypoint.sh / # buildkit                 1.26kB    buildkit.dockerfile.v0
    <missing>      2 weeks ago   RUN /bin/sh -c dnf -y clean all --enablerepo…   2.01MB    buildkit.dockerfile.v0
    <missing>      2 weeks ago   RUN /bin/sh -c mkdir -p /home/user && chgrp …   2.79GB    buildkit.dockerfile.v0  # 2.79 GB layer
    ```
    
* After 
    ```
    ❯ docker history quay.io/amisevsk/universal-developer-image:dev | head -n 5
    IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
    8888b8b5ebd0   12 minutes ago   USER 10001                                      0B        buildkit.dockerfile.v0
    <missing>      12 minutes ago   COPY entrypoint.sh / # buildkit                 1.26kB    buildkit.dockerfile.v0
    <missing>      12 minutes ago   RUN /bin/sh -c dnf -y clean all --enablerepo…   2.02MB    buildkit.dockerfile.v0
    <missing>      13 minutes ago   RUN /bin/sh -c mkdir -p /home/user && chgrp …   13MB      buildkit.dockerfile.v0 # Down to 13 MB
    ```

To enable this, I also had to update the base developer image Dockerfile, as it was previously copying a root-owned .gitconfig to `/home/user`, which meant that it was not possible to `chgrp` this file as user 10001. As a result, building the new udi dockerfile directly will not work until the new base developer image is built; for testing you can replace the `FROM` directive in the udi8 dockerfile with
```
FROM quay.io/amisevsk/base-developer-image:dev
```
