### PR TITLE
chore: define user directory for binaries

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -79,6 +79,11 @@ ENV KUBECONFIG=/home/user/.kube/config
 
 USER 0
 
+# Define user direcotry for binaries
+RUN mkdir -p /home/user/.local/bin && \
+    chgrp -R 0 /home && chmod -R g=u /home
+ENV PATH="/home/user/.local/bin:$PATH"
+
 # Required packages for AWT
 RUN dnf install -y libXext libXrender libXtst libXi
 
@@ -445,7 +450,7 @@ rm -rf "${TEMP_DIR}"
 EOF
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
-RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
+RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home
 
 # cleanup dnf cache
 RUN dnf -y clean all --enablerepo='*'

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -79,7 +79,7 @@ ENV KUBECONFIG=/home/user/.kube/config
 
 USER 0
 
-# Define user direcotry for binaries
+# Define user directory for binaries
 RUN mkdir -p /home/user/.local/bin && \
     chgrp -R 0 /home && chmod -R g=u /home
 ENV PATH="/home/user/.local/bin:$PATH"

--- a/universal/ubi8/entrypoint.sh
+++ b/universal/ubi8/entrypoint.sh
@@ -26,7 +26,6 @@ if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
 
     echo "Replacing podman with podman-wrapper..."
 
-    mkdir -p /home/user/.local/bin/
     ln -f -s /usr/bin/podman.wrapper /home/user/.local/bin/podman
 
     export TESTCONTAINERS_RYUK_DISABLED="true"
@@ -39,7 +38,6 @@ else
     echo "Kubedock is disabled. It can be enabled with the env variable \"KUBEDOCK_ENABLED=true\""
     echo "set in the workspace Devfile or in a Kubernetes ConfigMap in the developer namespace."
     echo
-    mkdir -p /home/user/.local/bin/
     ln -f -s /usr/bin/podman.orig /home/user/.local/bin/podman
 fi
 


### PR DESCRIPTION
`/home/user/.local/bin` directory may contain binaries, that could be inaccessible when using VS Code tasks. 

For instance, this directory contains a link to `podman`. If I launch VS Code task, environment variables appear to be not properly/completely initialized and `/home/user/.local/bin` is not added to `PATH`.

One of the solutions is to create a directory for binaries and add it to the `PATH` variable in the Dockerfile directly.

Required for https://github.com/eclipse/che/issues/22292

