### PR TITLE
Add parts to save disk space into Github workflow for increasing stability

### DIFF
--- a/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
+++ b/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Cleanup build-in images
       run: |
-        # remove build-in images from the VM becqause it is not used
+        # remove build-in images from the VM because it is not used
         docker rmi -f $(docker images -aq)
 
     - name: Start minikube cluster

--- a/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
+++ b/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
@@ -18,6 +18,7 @@ on:
       - .devfile.yaml
       - LICENSE
       - '.rebase/*'
+      - 'base/ubi9/**'
 
 env:
    USERSTORY: CloneGitRepoAPI
@@ -40,6 +41,11 @@ jobs:
         pr_number=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
         echo ">>>>>>>>>>>$pr_number"
+
+    - name: Cleanup build-in images
+      run: |
+        # remove build-in images from the VM becqause it is not used
+        docker rmi -f $(docker images -aq)
 
     - name: Start minikube cluster
       id: run-minikube
@@ -85,6 +91,8 @@ jobs:
 
     - name: Check that UDI is presen in the image list
       run: |
+        # we used it for previous building and do not need it anymore. It saves the disk space
+        minikube image rm quay.io/devfile/base-developer-image:ubi8-latest
         minikube image list --format table
 
     - name: Install NodeJs

--- a/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
+++ b/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Check that UDI is presen in the image list
       run: |
-        # we used it for previous building and do not need it anymore. It saves the disk space
+        # we used it for the build above and do not need it anymore. It saves the disk space
         minikube image rm quay.io/devfile/base-developer-image:ubi8-latest
         minikube image list --format table
 


### PR DESCRIPTION
* According to the issue: https://github.com/eclipse/che/issues/22509, we have instability runs on the latest verifications
* The root cause of the failures -  is limited Disk space in the provided GitHub Free plan - just 14 GB of disk space. We need to save disk space as much as possible. The main idea of this PR is to remove built-in images on the VM provided by the GitHub side. Potentially it can free about 1.5 GB. 
* Also, after building and using the universal base image, we may remove it. It can free about 450 MB. I hope this will help.
