### PR TITLE
chore: Remove redundant KUBECONFIG env var

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -77,9 +77,6 @@ ENV PATH=$NVM_DIR/versions/node/v${NODEJS_DEFAULT_VERSION}/bin:$PATH
 ENV NODEJS_HOME_20=$NVM_DIR/versions/node/v${NODEJS_20_VERSION}
 ENV NODEJS_HOME_18=$NVM_DIR/versions/node/v${NODEJS_18_VERSION}
 
-# kube
-ENV KUBECONFIG=/home/user/.kube/config
-
 USER 0
 
 # Define user directory for binaries


### PR DESCRIPTION
### What does this PR do
Remove redundant `KUBECONFIG` env var since kubeconfig is mounted as a Secret and env var is set by dashboard [1]

### Reference issue
https://issues.redhat.com/browse/CRW-4332

[1] https://github.com/eclipse-che/che-dashboard/pull/950