### PR TITLE
Pre-create common config directories

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -184,6 +184,17 @@ ENV KAMEL_VERSION 1.11.0
 RUN curl -L https://github.com/apache/camel-k/releases/download/v${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/kamel
 
+# Config directories
+RUN mkdir -p /home/tooling/.m2 && \
+    mkdir -p /home/tooling/.gradle && \
+    mkdir -p /home/tooling/.config/pip && \
+    mkdir -p /home/tooling/.sbt/1.0 && \
+    mkdir -p /home/tooling/.cargo && \
+    mkdir -p /home/tooling/certs && \
+    mkdir -p /home/tooling/.composer && \
+    mkdir -p /home/tooling/.nuget && \
+    chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
+
 # Cloud
 
 # oc client


### PR DESCRIPTION
This PR aims to fix eclipse/che#22029, with the scope limited to pre-creating config directories for the following common tools:
- Maven: `/home/user/.m2/`
- Gradle: `/home/user/.gradle/`
- Pip: `/home/user/.config/pip/`
- Cargo: `/home/user/.cargo/`
- Sbt: `/home/user/.sbt/1.0/`
- PHP: `/home/user/.composer/`
- .NET: `/home/user/.nuget`

As well as a `/home/user/certs/` directory.

Yarn & npm were excluded since they are supposed to be placed in the $HOME directory (`~/.yarnrc` ,` ~.npmrc`)

There might be other tools which support configuration files that I've missed in this PR, please feel free to suggest any.

I've pushed `quay.io/aobuchow/universal-developer-image:m2` for testing this PR, I also used the following [devfile](https://github.com/AObuchow/java-devfile-test/blob/main/devfile.yaml) for testing in Che:

```YAML
schemaVersion: 2.1.0
metadata:
  name: java-backend
projects:
  - name: springbootproject
    git:
      remotes:
        origin: https://github.com/odo-devfiles/springboot-ex.git
components:
  - name: tools
    container:
      image: quay.io/aobuchow/universal-developer-image:m2
      memoryLimit: 3Gi
commands:
  - id: build
    exec:
      component: tools
      workingDir: ${PROJECT_SOURCE}
      commandLine: mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true
      group:
        kind: build
        isDefault: true
  - id: run
    exec:
      component: tools
      workingDir: ${PROJECT_SOURCE}
      commandLine: mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run
      group:
        kind: run
        isDefault: true
  - id: debug
    exec:
      component: tools
      workingDir: ${PROJECT_SOURCE}
      commandLine: java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar
      group:
        kind: debug
        isDefault: true
```

## Testing
While logged into a cluster with Che installed, apply the following configmap list to your Che user namespace, it will create auto-mount configmaps (using the subPath mount method) for maven, gradle, sbt, pip and cargo:

```YAML
apiVersion: v1
kind: ConfigMap
metadata:
  name: workspace-sbt-config
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.sbt/1.0
data:
 global.sbt: |
    shellPrompt := { state =>
    s"\033[1;33m\033[43m[sbt ${name.value}]\033[0m >> "
    }
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: workspace-pip-config
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.config/pip
data:
 pip.conf: |
    [global]
    require-virtualenv = True
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: workspace-maven-config
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.m2
data:
 settings.xml: |
    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
    <localRepository>${user.home}/.m2/</localRepository>
    <interactiveMode>true</interactiveMode>
    <offline>true</offline>
    </settings>
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: workspace-gradle-config
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.gradle
data:
 gradle.properties: |
    org.gradle.java.home=/projects
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: workspace-cargo-config
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.cargo
data:
 config.toml: |
    [alias]     # command aliases
    myalias = "test"
```

Though it's a bit overkill, I made these configmaps to ensure the tool configurations could be read by the respective tools. 

### Maven (settings.xml)
Run the `mvn` command. Since `offline` is set to true, the command will fail with the following error message: 

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for com.example:demo:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.3.5.RELEASE (absent): Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.springframework.boot:spring-boot-starter-parent:pom:2.3.5.RELEASE has not been downloaded from it before. and 'parent.relativePath' points at no local POM @ line 5, column 10
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project com.example:demo:0.0.1-SNAPSHOT (/projects/springbootproject/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for com.example:demo:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.3.5.RELEASE (absent): Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.springframework.boot:spring-boot-starter-parent:pom:2.3.5.RELEASE has not been downloaded from it before. and 'parent.relativePath' points at no local POM @ line 5, column 10 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```


### Pip (pip.conf)
Run `pip install test`. Since we don't have a virtual environment created, and we're using `require-virtualenv = True`, you should get the following error: 

`ERROR: Could not find an activated virtualenv (required).`

### SBT 
Run `sbt -sbt-create`. Once the command completes (you'll see a few errors but it should still complete), the sbt prompt will be our custom prompt: `[sbt springbootproject] >>`

### Cargo (config.toml)

Run `cargo init && cargo myalias`. `myalias` is a custom alias for `test`, defined in our `config.toml`. You should see the following output:

```
    Finished test [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/main.rs (target/debug/deps/springbootproject-9d170e653f80aebf)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
