### PR TITLE
chore:update python to 3.11.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ docker run -ti --rm \
 |--------.NET---------|-------------------------------------|
 | `dotnet`            |`dotnet-sdk-6.0`                     |
 |------PYTHON---------|-------------------------------------|
-| `python`            |`python39`                           |
-| `setuptools`        |`python39-setuptools`                |
-| `pip`               |`python39-pip`                       |
+| `python`            |`python3.11`                           |
+| `setuptools`        |`python3.11-setuptools`                |
+| `pip`               |`python3.11-pip`                       |
 | `pylint`            |`<via pip>`                          |
 | `yq`                |`<via pip>`                          |
 |--------RUST---------|-------------------------------------|

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -131,15 +131,13 @@ ENV GOBIN="/home/tooling/go/bin/"
 ENV PATH="$GOBIN:$PATH"
 
 # Python
-RUN dnf -y module enable python39:3.9 && \
-    dnf -y update && \
-    dnf -y install python39 python39-devel python39-setuptools python39-pip nss_wrapper
+RUN dnf -y install python3.11 python3.11-devel python3.11-setuptools python3.11-pip nss_wrapper
 
 RUN cd /usr/bin \
-    && if [ ! -L python ]; then ln -s python3.9 python; fi \
-    && if [ ! -L pydoc ]; then ln -s pydoc3.9 pydoc; fi \
-    && if [ ! -L python-config ]; then ln -s python3.9-config python-config; fi \
-    && if [ ! -L pip ]; then ln -s pip-3.9 pip; fi
+    && if [ ! -L python ]; then ln -s python3.11 python; fi \
+    && if [ ! -L pydoc ]; then ln -s pydoc3.11 pydoc; fi \
+    && if [ ! -L python-config ]; then ln -s python3.11-config python-config; fi \
+    && if [ ! -L pip ]; then ln -s pip-3.11 pip; fi
 
 RUN pip install pylint yq
 


### PR DESCRIPTION
Updates python from 3.9 to 3.11

**Related issue:** https://issues.redhat.com/browse/CRW-4944

**To test:**

- Check that python 3.11 is installed in the image

or

- Run a python workspace using [![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/https://github.com/svor/python-hello-world/tree/che-python311) 