### PR TITLE
Set Java 17 as a default java

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -fsSL "https://get.sdkman.io/?rcupdate=false" | bash \
              && sdk install java 11.0.15-tem \
              && sdk install java 17.0.3-tem \
              && sdk install java 22.1.0.0.r17-mandrel \
-             && sdk default java 11.0.15-tem \
+             && sdk default java 17.0.3-tem \
              && sdk install gradle \
              && sdk install maven \
              && sdk install jbang \


### PR DESCRIPTION
Since premier support has ended for 8 (Mar 2022) and 11 (Sep 2023), set Java 17 as a default java 

**Related issue:**  https://issues.redhat.com/browse/CRW-4948

The changes are available with **quay.io/vsvydenk/udi:java17** image

It was checked with java-based samples:

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 11 23-15_52_32](https://github.com/devfile/developer-images/assets/1271546/d4f22569-21b1-41e3-bb2d-e478eb7ec0c4)

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 11 23-15_43_25](https://github.com/devfile/developer-images/assets/1271546/8c68154b-aef2-4f24-8e68-7757f0d3adb2)

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 11 23-15_12_32](https://github.com/devfile/developer-images/assets/1271546/35eb0703-2ba3-4d13-b6a2-11ec04a9edbd)

Only [lombok-project-sample](https://github.com/che-samples/lombok-project-sample) requires an update
