### PR TITLE
add clo monitor exemption for release

### DIFF
--- a/.clomonitor.yaml
+++ b/.clomonitor.yaml
@@ -1,0 +1,7 @@
+# CLOMonitor metadata file
+# This file must be located at the root of the repository
+
+# Checks exemptions
+exemptions:
+  - check: recent_release # Check identifier (see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions)
+    reason: "There are no releases planned for GitHub. Releases for images are done on a rolling basis to quay.io."

--- a/.clomonitor.yaml
+++ b/.clomonitor.yaml
@@ -4,4 +4,4 @@
 # Checks exemptions
 exemptions:
   - check: recent_release # Check identifier (see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions)
-    reason: "There are no releases planned for GitHub. Releases for images are done on a rolling basis to quay.io."
+    reason: "There are no releases planned for GitHub. Releases for images are done on a rolling basis to quay.io at quay.io/devfile/base-developer-image and quay.io/devfile/universal-developer-image."


### PR DESCRIPTION
All of the devfile repositories are currently being monitored on https://clomonitor.io/projects/cncf/devfile. As there are no releases planned for GitHub and the monitor is only tracking GitHub releases I am marking this as exempt on the monitor. The addition of the `.clomonitor.yaml` file allows this exemption to be properly tracked. Additionally it allows users who view the `developer-images` repo on the monitor to know that releases are going to `quay.io`.

fixes https://github.com/devfile/api/issues/1388