### PR TITLE
fix: remove android modules from ubuntu runner to free space

### DIFF
--- a/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
+++ b/.github/workflows/empty-worksapce-smoke-test-on-minikube-ubi8.yaml
@@ -33,7 +33,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@master
-
+    - name: Free runner space
+      run:
+        sudo rm -rf /usr/local/lib/android
       # obtain the PR number for tegging the image
     - name: Get PR number
       id: get_pr_number

--- a/.github/workflows/ubi8-build.yaml
+++ b/.github/workflows/ubi8-build.yaml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Free runner space
+        run:
+          sudo rm -rf /usr/local/lib/android
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/ubi9-build.yaml
+++ b/.github/workflows/ubi9-build.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Free runner space
+        run:
+          sudo rm -rf /usr/local/lib/android
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
GH Actions run into space limits, so remove unneeded modules from ubuntu runner, like android

related issue https://github.com/eclipse/che/issues/22876