### PR TITLE
Update oc to 4.15

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -196,8 +196,8 @@ RUN mkdir -p /home/tooling/.m2 && \
 # Cloud
 
 # oc client
-ENV OC_VERSION=4.6
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz | tar -C /usr/local/bin -xz \
+ENV OC_VERSION=4.15
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xz \
     && chmod +x /usr/local/bin/oc
 
 # OS Pipelines CLI (tkn)


### PR DESCRIPTION
after 4.6, mirror has changed of place as indicated on https://mirror.openshift.com/pub/openshift-v4/clients/oc/%24__DEPRECATED_LOCATION__PLEASE_READ__.txt

`Please direct x86_64 users and automation to the new oc client locations under: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/`