### PR TITLE
chore: update Node.js version to 18.19.1

### DIFF
--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -76,8 +76,7 @@ ENV PATH="/home/tooling/.local/share/coursier/bin:$PATH"
 RUN mkdir -p /home/tooling/.nvm/
 ENV NVM_DIR="/home/tooling/.nvm"
 ENV NODEJS_20_VERSION=20.7.0
-# note that 18.18.0 is the latest but 18.16.1 is the supported version downstream and in ubi8
-ENV NODEJS_18_VERSION=18.16.1
+ENV NODEJS_18_VERSION=18.19.1
 ENV NODEJS_DEFAULT_VERSION=${NODEJS_18_VERSION}
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | PROFILE=/dev/null bash
 RUN echo 'export NVM_DIR="$HOME/.nvm"' >> ${PROFILE_EXT} \


### PR DESCRIPTION


```
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] Resolving packages...
[2/4] Fetching packages...
warning Pattern ["string-width@^4.1.0"] is trying to unpack in the same destination "/home/user/.cache/yarn/v6/npm-string-width-cjs-4.2.3-integrity/node_modules/string-width-cjs" as pattern ["string-width-cjs@npm:string-width@^4.2.0"]. This could result in non-deterministic behavior, skipping.
error next@14.1.3: The engine "node" is incompatible with this module. Expected version ">=18.17.0". Got "18.16.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```