### PR TITLE
Update dotnet  from 6.0 to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker run -ti --rm \
 | `go`                |`go-toolset`                         |
 | `gopls`             |`golang.org/x/tools/gopls`           |
 |--------.NET---------|-------------------------------------|
-| `dotnet`            |`dotnet-sdk-6.0`                     |
+| `dotnet`            |`dotnet-sdk-8.0`                     |
 |------PYTHON---------|-------------------------------------|
 | `python`            |`python3.11`                         |
 | `setuptools`        |`python3.11-setuptools`              |

--- a/universal/ubi8/Dockerfile
+++ b/universal/ubi8/Dockerfile
@@ -165,7 +165,7 @@ ENV PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear \
     HTTPD_VAR_PATH=/var
 
 # .NET
-ENV DOTNET_RPM_VERSION=6.0
+ENV DOTNET_RPM_VERSION=8.0
 RUN dnf install -y dotnet-hostfxr-${DOTNET_RPM_VERSION} dotnet-runtime-${DOTNET_RPM_VERSION} dotnet-sdk-${DOTNET_RPM_VERSION}
 
 # rust


### PR DESCRIPTION
Update dotnet version from 6.0 to 8.0, latest LTS version at this time.

Signed-off-by: Alex Popescu <pop.alx@gmail.com>