### PR TITLE
Fix: pin stow to version 2.3.1

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /home/tooling/
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf update -y && \
     dnf install -y bash curl diffutils git git-lfs iproute jq less lsof man nano procps p7zip p7zip-plugins \
-                   perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip stow && \
+                   perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip make && \
                    dnf clean all
 
 ## gh-cli
@@ -90,6 +90,30 @@ RUN \
     mv "fd-v${FD_VERSION}-${FD_ARCH}"/fd.1 /usr/local/share/man/man1 && \
     cd - && \
     rm -rf "${TEMP_DIR}"
+
+## stow
+RUN \
+    TEMP_DIR="$(mktemp -d)"; \
+    cd "${TEMP_DIR}"; \
+    STOW_VERSION="2.3.1"; \
+    STOW_TGZ="stow-${STOW_VERSION}.tar.gz"; \
+    GNU_KEYRING="gnu-keyring.gpg"; \
+    STOW_TGZ_URL="http://ftpmirror.gnu.org/stow/${STOW_TGZ}"; \
+    STOW_CHEKSUMS_URL="http://ftpmirror.gnu.org/stow/${STOW_TGZ}.sig"; \
+    GNU_KEYRING_URL="https://ftp.gnu.org/gnu/gnu-keyring.gpg"; \
+    curl -sSLO "${STOW_TGZ_URL}" && \
+    curl -sSLO "${STOW_CHEKSUMS_URL}" && \
+    curl -sSLO "${GNU_KEYRING_URL}" && \
+    gpg --verify --keyring ./${GNU_KEYRING} "${STOW_TGZ}".sig "${STOW_TGZ}" && \
+    rm -rf ${HOME}/.gnupg && \
+    tar -zxv --no-same-owner -f "${STOW_TGZ}" && \
+    cd stow-${STOW_VERSION} && \
+    mkdir -p ./build && \
+    ./configure --prefix=${TEMP_DIR}/build && \
+    make install && \
+    cp -r ${TEMP_DIR}/build/bin/. /usr/bin/ && \
+    cp -r ${TEMP_DIR}/build/share/. /usr/share/ && \
+    stow --version
 
 COPY --chown=0:0 entrypoint.sh /
 COPY --chown=0:0 .stow-local-ignore /home/tooling/


### PR DESCRIPTION
Stow recently released version 2.4.0, which [does not allow](https://github.com/eclipse-che/che/issues/22957#issue-2285143021) stowing absolute symbolic links. As a temporary workaround, this PR downgrades stow back to version 2.3.1.

Stow is being downloaded from a GNU mirror, and then verified using the official GNU keyring (see the bottom of https://ftp.gnu.org/README). We remove the GNU gpg related files once we're done with them.

Unfortunately, the binary of stow is not available for direct usage, so stow is built and then moved to `/usr/bin/` so that it is available on $PATH to be used for the rest of the UBI & UDI builds (moving stow to `/usr/local/bin/` didn't seem to put it on $PATH).

Fixes https://github.com/eclipse-che/che/issues/22957