### PR TITLE
Remove unused /home/tooling/.local

### DIFF
--- a/base/ubi8/Dockerfile
+++ b/base/ubi8/Dockerfile
@@ -32,7 +32,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 RUN dnf -y module enable container-tools:rhel8 && \
     dnf -y update && \
     dnf -y reinstall shadow-utils && \
-    dnf -y install podman buildah skopeo fuse-overlayfs
+    dnf -y install podman buildah skopeo fuse-overlayfs && \
+    dnf clean all
 
 ## gh-cli
 RUN \
@@ -97,12 +98,8 @@ RUN \
     cd - && \
     rm -rf "${TEMP_DIR}"
 
-
 # Define user directory for binaries
-RUN mkdir -p /home/tooling/.local/bin && \
-    chgrp -R 0 /home && chmod -R g=u /home && chown -R 10001 /home/tooling
 ENV PATH="/home/user/.local/bin:$PATH"
-ENV PATH="/home/tooling/.local/bin:$PATH"
 
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to
@@ -135,11 +132,11 @@ COPY --chown=0:0 kubedock_setup.sh /usr/local/bin/kubedock_setup
 
 # Configure Podman wrapper
 ENV PODMAN_WRAPPER_PATH=/usr/bin/podman.wrapper
-ENV PODMAN_ORIGINAL_PATH=/usr/bin/podman.orig
+ENV ORIGINAL_PODMAN_PATH=/usr/bin/podman.orig
 COPY --chown=0:0 podman-wrapper.sh "${PODMAN_WRAPPER_PATH}"
 
 COPY --chown=0:0 podman-wrapper.sh /usr/bin/podman.wrapper
-RUN mv /usr/bin/podman /usr/bin/podman.orig
+RUN mv /usr/bin/podman "${ORIGINAL_PODMAN_PATH}"
 
 COPY --chown=0:0 entrypoint.sh /
 COPY --chown=0:0 .stow-local-ignore /home/tooling/

--- a/base/ubi8/kubedock_setup.sh
+++ b/base/ubi8/kubedock_setup.sh
@@ -2,6 +2,12 @@
 
 # Kubedock setup script meant to be run from the entrypoint script.
 
+LOCAL_BIN=/home/user/.local/bin
+ORIGINAL_PODMAN_PATH=${ORIGINAL_PODMAN_PATH:-"/usr/bin/podman.orig"}
+PODMAN_WRAPPER_PATH=${PODMAN_WRAPPER_PATH:-"/usr/bin/podman.wrapper"}
+
+mkdir -p "${LOCAL_BIN}"
+
 if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
   echo
   echo "Kubedock is enabled (env variable KUBEDOCK_ENABLED is set to true)."
@@ -29,7 +35,7 @@ if [ "${KUBEDOCK_ENABLED:-false}" = "true" ]; then
 
     echo "Replacing podman with podman-wrapper..."
 
-    ln -f -s /usr/bin/podman.wrapper /home/tooling/.local/bin/podman
+    ln -f -s "${PODMAN_WRAPPER_PATH}" "${LOCAL_BIN}/podman"
 
     export TESTCONTAINERS_RYUK_DISABLED="true"
     export TESTCONTAINERS_CHECKS_DISABLE="true"
@@ -45,5 +51,5 @@ else
   echo "Kubedock is disabled. It can be enabled with the env variable \"KUBEDOCK_ENABLED=true\""
   echo "set in the workspace Devfile or in a Kubernetes ConfigMap in the developer namespace."
   echo
-  ln -f -s /usr/bin/podman.orig /home/tooling/.local/bin/podman
+  ln -f -s "${ORIGINAL_PODMAN_PATH}" "${LOCAL_BIN}/podman"
 fi

--- a/base/ubi8/podman-wrapper.sh
+++ b/base/ubi8/podman-wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-ORIGINAL_PODMAN_PATH=${ORIGINAL_PODMAN_PATH:-"/usr/bin/podman.orig"}
+PODMAN_ORIGINAL_PATH=${PODMAN_ORIGINAL_PATH:-"/usr/bin/podman.orig"}
 KUBEDOCK_SUPPORTED_COMMANDS=${KUBEDOCK_SUPPORTED_COMMANDS:-"run ps exec cp logs inspect kill rm wait stop start"}
 
 PODMAN_ARGS=( "$@" )
@@ -10,11 +10,11 @@ TRUE=0
 FALSE=1
 
 exec_original_podman() {
-    exec ${ORIGINAL_PODMAN_PATH} "${PODMAN_ARGS[@]}"
+    exec ${PODMAN_ORIGINAL_PATH} "${PODMAN_ARGS[@]}"
 }
 
 exec_kubedock_podman() {
-    exec env CONTAINER_HOST=tcp://127.0.0.1:2475 "${ORIGINAL_PODMAN_PATH}" "${PODMAN_ARGS[@]}"
+    exec env CONTAINER_HOST=tcp://127.0.0.1:2475 "${PODMAN_ORIGINAL_PATH}" "${PODMAN_ARGS[@]}"
 }
 
 podman_command() {


### PR DESCRIPTION
This PR fixes the issue where podman was not found when there is a volume mounted to /home/user/.local.

Fixes https://github.com/eclipse-che/che/issues/23095

In the base image, before this PR an empty `/home/tooling/.local` directory is created. Stowing this empty directory to `/home/user` created a hard link for the /home/.local directory, which caused both `/home/user/.local` and `/home/tooling/.local` to be affected by the volume mount to `/home/user/.local`.

This PR removes the `/home/tooling/.local` directory, since it was not used at all in the Dockerfile, and was only used in the entrypoint to store the podman wrapper. In this PR, the podman wrapper set up by the entrypoint is now stored in `/home/user/.local` instead.

### To test this PR

1. Build the base image:
```
$ cd base/ubi8
$ DOCKER_BUILDKIT=1 docker image build --progress=plain -t quay.io/<username>/<repo>:base-image .
```
I've built my own here: quay.io/dkwon17/developer-images:base-image

2. Push the image to quay.

3. Start the following workspace:
```
<CHE-HOST>#https://github.com/redhat-developer/devspaces/tree/devspaces-3-rhel-8?image=quay.io/<username>/<repo>:base-image
```
4. In the terminal, there should be no problems with running `podman info`
```
devspaces (devspaces-3-rhel-8) $ podman info
host:
  arch: amd64
  buildahVersion: 1.33.8
  cgroupControllers:
...
```

And `which podman` should output the following:
```
devspaces (devspaces-3-rhel-8) $ which podman
~/.local/bin/podman
```




