### PR TITLE
Fix home directory ownership so that podman 5.2.2 does not error

### DIFF
--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -117,11 +117,6 @@ RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; \
     touch /var/lib/shared/overlay-images/images.lock; \
     touch /var/lib/shared/overlay-layers/layers.lock
 
-# But use VFS since not all environments support overlay with Fuse backend
-RUN mkdir -p "${HOME}"/.config/containers && \
-   (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf && \
-   chown -R 10001 "${HOME}"/.config
-
 # Add kubedock
 ENV KUBEDOCK_VERSION 0.17.0
 ENV KUBECONFIG=/home/user/.kube/config

--- a/base/ubi9/entrypoint.sh
+++ b/base/ubi9/entrypoint.sh
@@ -5,6 +5,13 @@ if [ ! -d "${HOME}" ]; then
   mkdir -p "${HOME}"
 fi
 
+# Configure container builds to use vfs
+if [ ! -d "${HOME}/.config/containers" ]
+then
+  mkdir -p ${HOME}/.config/containers
+  (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf
+fi
+
 # Setup $PS1 for a consistent and reasonable prompt
 if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
   echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc


### PR DESCRIPTION
With the update of `podman` from 4.9.4 to 5.2.2 in UBI 9, podman fails to run if the ownership of $HOME/.config is incorrect.

This PR fixes that by moving the creation of $HOME and ${HOME}/.config/containers to the `ENTRYPOINT`.