### PR TITLE
chore: bumping memoryLimit in devfile

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -8,5 +8,5 @@ components:
   - name: devtools
     container:
       image: quay.io/devfile/universal-developer-image:ubi9-latest
-      memoryLimit: 2Gi
+      memoryLimit: 6Gi
       memoryRequest: 256Mi


### PR DESCRIPTION
can build the base, but not the universal on Developer Sandbox: 

<img width="1198" alt="Screenshot 2024-12-11 at 14 48 58" src="https://github.com/user-attachments/assets/37800fc3-83c6-4a03-a5cd-cd18fcb295b7" />
