### PR TITLE
Keep gopls version to golang.org/x/tools/gopls v0.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ docker run -ti --rm \
 | `yarn`              |`<via npm>`                          |
 |--------GO-----------|-------------------------------------|
 | `go`                |`go-toolset`                         |
-| `gopls`             |`golang.org/x/tools/gopls`           |
+| `gopls`             |`golang.org/x/tools/gopls v0.16.2`   |
 |--------.NET---------|-------------------------------------|
 | `dotnet`            |`dotnet-sdk-8.0`                     |
 |------PYTHON---------|-------------------------------------|

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -117,10 +117,10 @@ RUN curl -fLo mill https://raw.githubusercontent.com/lefou/millw/main/millw && \
 # C/CPP
 RUN dnf -y install llvm-toolset gcc gcc-c++ clang clang-libs clang-tools-extra gdb
 
-# Go 1.18+    - installed to /usr/bin/go
-# gopls 0.10+ - installed to /home/tooling/go/bin/gopls and /home/tooling/go/pkg/mod/
+# Go 1.22+    - installed to /usr/bin/go
+# gopls 0.16.2+ - installed to /home/tooling/go/bin/gopls and /home/tooling/go/pkg/mod/
 RUN dnf install -y go-toolset && \
-    GO111MODULE=on go install -v golang.org/x/tools/gopls@latest && \
+    GO111MODULE=on go install -v golang.org/x/tools/gopls@v0.16.2 && \
     chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
 ENV GOBIN="/home/tooling/go/bin/"
 ENV PATH="$GOBIN:$PATH"


### PR DESCRIPTION
Gopls v0.17.0 was released recently on Dec 11, which breaks the UDI build with this error:
```
#20 6.448 go: golang.org/x/tools/gopls@latest: golang.org/x/tools/gopls@v0.17.0 requires go >= 1.23.1 (running go 1.22.7; GOTOOLCHAIN=local)
```

This PR updates the dockerfile to use gopls v0.16.2 which is compatible with go version 1.22.7.

To test this PR, run:
```
cd universal/ubi9 && DOCKER_BUILDKIT=1 docker image build --progress=plain -t quay.io/devfile/universal-developer-image:ubi9-latest .
```

and verify that the build succeeds.