### PR TITLE
fix: Update gh cli to 2.67.0

### DIFF
--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -37,11 +37,11 @@ RUN dnf -y reinstall shadow-utils && \
     dnf clean all
 
 # Download and install gh-cli depending on the architecture.
-# See release page for details https://github.com/cli/cli/releases/tag/v2.45.0
+# See release page for details https://github.com/cli/cli/releases/tag/v2.67.0
 RUN \
     TEMP_DIR="$(mktemp -d)"; \
     cd "${TEMP_DIR}"; \
-    GH_VERSION="2.45.0"; \
+    GH_VERSION="2.67.0"; \
     GH_ARCH="linux_$TARGETARCH"; \
     GH_TGZ="gh_${GH_VERSION}_${GH_ARCH}.tar.gz"; \
     GH_TGZ_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TGZ}"; \


### PR DESCRIPTION
The installed version of gh-cli includes several vulnerabilities:

CRITICAL:
CVE-2024-24790
GHSA-v778-237x-gjrc

HIGH:
CVE-2023-45288
CVE-2024-24784
CVE-2024-24791
CVE-2024-34156
CVE-2024-34158
GHSA-p2h2-3vg9-4p87
GHSA-w32m-9786-jp63

There are also a number of medium vulnerabilities.

This update should clear some or all vulnerabilities