### PR TITLE
chore: add workflow-dispatch event into ui9-build GH action

### DIFF
--- a/.github/workflows/ubi9-build.yaml
+++ b/.github/workflows/ubi9-build.yaml
@@ -4,6 +4,7 @@ name: Build of UBI 9 based Developer Images
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
   workflow_call:
     # Map the workflow outputs to job outputs


### PR DESCRIPTION
This PR adds support for manually triggering the UBI 9 base developer image build workflow via the GitHub UI