### PR TITLE
feat: Update latest version of base image, moving to RH 9.6 from 9.5

### DIFF
--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
 # https://registry.access.redhat.com/ubi9/ubi
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1739449058
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1747219013
 
 ARG TARGETARCH
 LABEL maintainer="Red Hat, Inc."


### PR DESCRIPTION
This moves the base image over to the latest RHEL 9 base image