### PR TITLE
fix: create links in entrypoint for files under /home/tooling/.config

### DIFF
--- a/base/ubi9/.copy-files
+++ b/base/ubi9/.copy-files
@@ -1,0 +1,22 @@
+# This file contains a list directories or files to copy over from /home/tooling to /home/user in entrypoint.sh.
+#
+# For example, the follwing will copy /home/tooling/testfile to /home/user/testfile:
+# ./testfile
+#
+# The goal of this file is to copy over files that cannot be used as symbolic links created by stow.
+# For example, Vim does not permit .viminfo to be a symbolic link for security reasons, therefore it is copied 
+# over to /home/user manually without stow.
+#
+# When copying over directories or files from /home/tooling to /home/user using this file, remember to add the
+# directory or file to .stow-local-ignore so that a symbolic link is not created.
+
+
+# Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it
+.viminfo
+
+# We have to restore bash-related files back onto /home/user/ (since they will have been overwritten by the PVC)
+# but we don't want them to be symbolic links (so that they persist on the PVC)
+.bashrc
+.bash_profile
+
+./foo

--- a/base/ubi9/.copy-files
+++ b/base/ubi9/.copy-files
@@ -1,6 +1,6 @@
 # This file contains a list directories or files to copy over from /home/tooling to /home/user in entrypoint.sh.
 #
-# For example, the follwing will copy /home/tooling/testfile to /home/user/testfile:
+# For example, the following will copy /home/tooling/testfile to /home/user/testfile:
 # ./testfile
 #
 # The goal of this file is to copy over files that cannot be used as symbolic links created by stow.
@@ -18,5 +18,3 @@
 # but we don't want them to be symbolic links (so that they persist on the PVC)
 .bashrc
 .bash_profile
-
-./foo

--- a/base/ubi9/entrypoint.sh
+++ b/base/ubi9/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Replace /home/tooling/* path to /home/user/* path
+replace_user_home() {
+  echo "$1" | sed "s|^/home/tooling|$HOME|"
+}
+
 # Ensure $HOME exists when starting
 if [ ! -d "${HOME}" ]; then
   mkdir -p "${HOME}"
@@ -15,11 +20,20 @@ if [ ! -d "${HOME}/.config/containers" ]; then
   fi
 fi
 
-# Create Sym Link for Composer Keys in /home/tooling/.config
-if [ -d /home/tooling/.config/composer ] && [ ! -d "${HOME}/.config/composer" ]; then
-  mkdir -p ${HOME}/.config/composer
-  ln -s /home/tooling/.config/composer/keys.dev.pub ${HOME}/.config/composer/keys.dev.pub
-  ln -s /home/tooling/.config/composer/keys.tags.pub ${HOME}/.config/composer/keys.tags.pub
+# Find files under /home/tooling/.config and create symlinks. The /home/tooling/.config folder
+# is ignored by stow with the .stow-local-ignore file
+if [ -d /home/tooling/.config ]; then
+  for file in $(find /home/tooling/.config -type f); do
+    tooling_dir=$(dirname "$file")
+
+    # Create dir in /home/user if it does not exist already
+    mkdir -p $(replace_user_home "$tooling_dir")
+
+    # Create symbolic link if it does not exist already
+    if [ ! -f $(replace_user_home $file) ]; then
+      ln -s $file $(replace_user_home $file)
+    fi
+  done
 fi
 
 # Setup $PS1 for a consistent and reasonable prompt


### PR DESCRIPTION
Files under `/home/tooling/.config` are not stowed in the entrypoint because it is in the `.stow-local-ignore` file. Stow ignores everything in the `.config` folder because the `/home/user/.config` folder should be created in the entrypoint in order to have proper user permissions required for Podman 5.x.

This PR fixes https://issues.redhat.com/browse/CRW-8932

See https://github.com/devfile/developer-images/pull/197

How I tested this PR:

1. Build the base image. My base image is: `quay.io/dkwon17/base-developer-image:persist-config-files`.
```
cd base/ubi9 && podman image build -t  {base image} .
```

2. Create the following files somewhere in your filesystem:

<details><summary>Dockerfile</summary>

```
FROM {base image}

COPY test.conf /home/tooling/.config/test/test-nested.conf
COPY test.conf /home/tooling/.config/test.conf
COPY test.conf /home/tooling/.config/test/another/test1.conf
COPY test.conf /home/tooling/.config/test/another/test2.conf
COPY test.conf /home/tooling/.config/composer/keys.dev.pub
COPY test.conf /home/tooling/.config/composer/keys.tags.pub
```

</details>

<details><summary>test.conf</summary>

```
test file
```

</details>

3. Build the image from step 2. I've named my image `quay.io/dkwon17/test:persist-config-files`
```
podman build -t {image}.
```

4. Run the image (`podman run {image}`) and exec into it. Verify that there are links from files under `/home/tooling/.config` to `/home/user/.config`:

```
~ $ cd .config/
.config $ ls -la
total 4
drwxr-xr-x. 1 user user 62 Jul 10 21:33 .
drwxrwx---. 1 user root 26 Jul 10 21:33 ..
drwxr-xr-x. 1 user user 50 Jul 10 21:33 composer
drwxr-xr-x. 1 user user 24 Jul 10 21:33 containers
drwxr-xr-x. 1 user user 46 Jul 10 21:33 test
lrwxrwxrwx. 1 user user 31 Jul 10 21:33 test.conf -> /home/tooling/.config/test.conf
.config $ cd test
test $ ls -la
total 4
drwxr-xr-x. 1 user user 46 Jul 10 21:33 .
drwxr-xr-x. 1 user user 62 Jul 10 21:33 ..
drwxr-xr-x. 1 user user 40 Jul 10 21:33 another
lrwxrwxrwx. 1 user user 43 Jul 10 21:33 test-nested.conf -> /home/tooling/.config/test/test-nested.conf
test $ cd another/
another $ ls -la
total 8
drwxr-xr-x. 1 user user 40 Jul 10 21:33 .
drwxr-xr-x. 1 user user 46 Jul 10 21:33 ..
lrwxrwxrwx. 1 user user 45 Jul 10 21:33 test1.conf -> /home/tooling/.config/test/another/test1.conf
lrwxrwxrwx. 1 user user 45 Jul 10 21:33 test2.conf -> /home/tooling/.config/test/another/test2.conf
another $ cd ../../composer/
composer $ ls -la
total 8
drwxr-xr-x. 1 user user 50 Jul 10 21:33 .
drwxr-xr-x. 1 user user 62 Jul 10 21:33 ..
lrwxrwxrwx. 1 user user 43 Jul 10 21:33 keys.dev.pub -> /home/tooling/.config/composer/keys.dev.pub
lrwxrwxrwx. 1 user user 44 Jul 10 21:33 keys.tags.pub -> /home/tooling/.config/composer/keys.tags.pub
```