### PR TITLE
Add .copy-files file which copies over files from /home/tooling to /h…

### DIFF
--- a/base/ubi9/.stow-local-ignore
+++ b/base/ubi9/.stow-local-ignore
@@ -13,3 +13,5 @@
 
 # Ignore files under .config directory
 \.config
+
+\.copy-files

--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -152,6 +152,7 @@ RUN mv /usr/bin/podman "${ORIGINAL_PODMAN_PATH}"
 
 COPY --chown=0:0 entrypoint.sh /
 COPY --chown=0:0 .stow-local-ignore /home/tooling/
+COPY --chown=0:0 .copy-files /home/tooling/
 RUN \
     # add user and configure it
     useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \

--- a/base/ubi9/entrypoint.sh
+++ b/base/ubi9/entrypoint.sh
@@ -90,12 +90,17 @@ if [ $HOME_USER_MOUNTED -eq 0 ] && [ ! -f $STOW_COMPLETE ]; then
     #
     # Create symbolic links from /home/tooling/ -> /home/user/
     stow . -t /home/user/ -d /home/tooling/ --no-folding -v 2 > /tmp/stow.log 2>&1
-    # Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it
-    cp /home/tooling/.viminfo /home/user/.viminfo
-    # We have to restore bash-related files back onto /home/user/ (since they will have been overwritten by the PVC)
-    # but we don't want them to be symbolic links (so that they persist on the PVC)
-    cp /home/tooling/.bashrc /home/user/.bashrc
-    cp /home/tooling/.bash_profile /home/user/.bash_profile
+
+    # Read .copy-files and copy files from /home/tooling to /home/user
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip empty and commented lines
+        [[ -z "$line" || "$line" == \#* ]] && continue
+
+        tooling_path=$(realpath "/home/tooling/$line")
+        user_path=$(realpath "/home/user/$line")
+        cp --no-clobber -r $tooling_path $user_path
+    done < /home/tooling/.copy-files
+
     touch $STOW_COMPLETE
 fi
 


### PR DESCRIPTION
…ome/user in the entrypoint

This PR is an upstream equivalent of this PR: https://github.com/redhat-developer/devspaces-images/pull/770

For https://issues.redhat.com/browse/CRW-8598 and https://issues.redhat.com/browse/CRW-8932

To test this PR:

Build the base image:
```
$ cd base/ubi9 && DOCKER_BUILDKIT=1 docker image build --progress=plain -t <BASE_IMAGE> .
```

Create these 4 empty files:
```
.
└── some-directory/
    ├── config
    ├── config2
    ├── case1.Dockerfile
    └── case2.Dockerfile
```


<details><summary>Case 1: Testing CRW-8932</summary>

Put the following into `case1.Dockerfile`:
```
FROM <BASE_IMAGE>

RUN mkdir -p /home/tooling/.config/test

COPY config2 /home/tooling/.config/test/
COPY config /home/tooling/.config/

USER root
RUN chmod 777 /home/tooling/.config/test/config2 /home/tooling/.config/config

USER 1001
```

Build the image:
```
docker build -t quay.io/<your_username>/base-developer-image:case1 -f case1.Dockerfile . && docker push quay.io/<your_username>/base-developer-image:case1
```

Create a workspace with the new image. My new image is: `quay.io/dkwon17/base-developer-image:case1`:
```
<CHE_HOST>#https://github.com/che-samples/bash?image=quay.io/dkwon17/base-developer-image:case1&storageType=per-workspace
```

Verify that there are symlinks for `config` and `config2`:
```
$ ls -la /home/user/.config
total 0
drwxr-xr-x. 4 user root 50 Aug 22 20:57 .
drwxrwx---. 1 user root 62 Aug 22 20:57 ..
lrwxrwxrwx. 1 user root 28 Aug 22 20:57 config -> /home/tooling/.config/config
drwxr-xr-x. 2 user root 26 Aug 22 20:57 containers
drwxr-xr-x. 2 user root 21 Aug 22 20:57 test

$ ls -la /home/user/.config/test
total 0
drwxr-xr-x. 2 user root 21 Aug 22 20:57 .
drwxr-xr-x. 4 user root 50 Aug 22 20:57 ..
lrwxrwxrwx. 1 user root 34 Aug 22 20:57 config2 -> /home/tooling/.config/test/config2
```

</details>

<details><summary>Case 2: Testing CRW-8598</summary>

Put the following into `case2.Dockerfile`:
```
FROM <BASE_IMAGE>

RUN mkdir -p /home/tooling/.config/test

COPY config2 /home/tooling/.config/test/
COPY config /home/tooling/.config/

RUN echo ".config/test" >> /home/tooling/.copy-files

USER root

RUN chmod 777 /home/tooling/.config/test/config2

USER 1001
```

Build the image:
```
docker build -t quay.io/<your_username>/base-developer-image:case2 -f case2.Dockerfile . && docker push quay.io/<your_username>/base-developer-image:case2
```

Create a workspace with the new image. My new image is: `quay.io/dkwon17/base-developer-image:case2`:
```
<CHE_HOST>#https://github.com/che-samples/bash?image=quay.io/dkwon17/base-developer-image:case2&storageType=per-workspace
```

Verify that `/home/user/.config/test/config2` exists, and is not a symlink:
```
$ ls -la /home/user/.config/test
total 4
drwxr-xr-x. 2 user root 21 Aug 22 21:28 .
drwxr-xr-x. 4 user root 50 Aug 22 21:27 ..
-rwxr-xr-x. 1 user root 18 Aug 22 21:28 config2
```

Make a change to the `config2` file, and restart the workspace. Once the workpsace is restarted, the `config2` file should have the changes you made before restarting the workspace.


</details>
