### PR TITLE
Update .config symlink logic and add .copy-files logic

### DIFF
--- a/base/ubi9/.stow-local-ignore
+++ b/base/ubi9/.stow-local-ignore
@@ -13,3 +13,5 @@
 
 # Ignore files under .config directory
 \.config
+
+\.copy-files

--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -152,6 +152,7 @@ RUN mv /usr/bin/podman "${ORIGINAL_PODMAN_PATH}"
 
 COPY --chown=0:0 entrypoint.sh /
 COPY --chown=0:0 .stow-local-ignore /home/tooling/
+COPY --chown=0:0 .copy-files /home/tooling/
 RUN \
     # add user and configure it
     useradd -u 10001 -G wheel,root -d /home/user --shell /bin/bash -m user && \

--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -163,7 +163,7 @@ RUN \
     # Copy the global git configuration to user config as global /etc/gitconfig
     # file may be overwritten by a mounted file at runtime
     cp /etc/gitconfig ${HOME}/.gitconfig && \
-    chown 10001 ${HOME}/ ${HOME}/.viminfo ${HOME}/.gitconfig ${HOME}/.stow-local-ignore && \
+    chown 10001 ${HOME}/ ${HOME}/.viminfo ${HOME}/.gitconfig ${HOME}/.stow-local-ignore ${HOME}/.copy-files && \
     # Set permissions on /etc/passwd and /home to allow arbitrary users to write
     chgrp -R 0 /home && \
     chmod -R g=u /etc/passwd /etc/group /home && \


### PR DESCRIPTION
For https://issues.redhat.com/browse/CRW-8932 and https://issues.redhat.com/browse/CRW-8598.

To test this PR:

Build the base image:
```
$ cd base/ubi9 && DOCKER_BUILDKIT=1 docker image build --progress=plain -t <BASE_IMAGE> .
```

Create these 4 empty files:
```
.
└── some-directory/
    ├── config
    ├── config2
    ├── case1.Dockerfile
    └── case2.Dockerfile
```


<details><summary>Case 1: Testing CRW-8932</summary>

Put the following into `case1.Dockerfile`:
```
FROM <BASE_IMAGE>

RUN mkdir -p /home/tooling/.config/test

COPY config2 /home/tooling/.config/test/
COPY config /home/tooling/.config/

USER root
RUN chmod 777 /home/tooling/.config/test/config2 /home/tooling/.config/config

USER 1001
```

Build the image:
```
docker build -t quay.io/<your_username>/base-developer-image:case1 -f case1.Dockerfile . && docker push quay.io/<your_username>/base-developer-image:case1
```

Create a workspace with the new image. My new image is: `quay.io/dkwon17/base-developer-image:case1`:
```
<CHE_HOST>#https://github.com/che-samples/bash?image=quay.io/dkwon17/base-developer-image:case1&storageType=per-workspace
```

Verify that there are symlinks for `config` and `config2`:
```
$ ls -la /home/user/.config
total 0
drwxr-xr-x. 4 user root 50 Aug 22 20:57 .
drwxrwx---. 1 user root 62 Aug 22 20:57 ..
lrwxrwxrwx. 1 user root 28 Aug 22 20:57 config -> /home/tooling/.config/config
drwxr-xr-x. 2 user root 26 Aug 22 20:57 containers
drwxr-xr-x. 2 user root 21 Aug 22 20:57 test

$ ls -la /home/user/.config/test
total 0
drwxr-xr-x. 2 user root 21 Aug 22 20:57 .
drwxr-xr-x. 4 user root 50 Aug 22 20:57 ..
lrwxrwxrwx. 1 user root 34 Aug 22 20:57 config2 -> /home/tooling/.config/test/config2
```

</details>

<details><summary>Case 2: Testing CRW-8598</summary>

Put the following into `case2.Dockerfile`:
```
FROM <BASE_IMAGE>

RUN mkdir -p /home/tooling/.config/test

COPY config2 /home/tooling/.config/test/
COPY config /home/tooling/.config/

RUN echo ".config/test" >> /home/tooling/.copy-files

USER root

RUN chmod 777 /home/tooling/.config/test/config2

USER 1001
```

Build the image:
```
docker build -t quay.io/<your_username>/base-developer-image:case2 -f case2.Dockerfile . && docker push quay.io/<your_username>/base-developer-image:case2
```

Create a workspace with the new image. My new image is: `quay.io/dkwon17/base-developer-image:case2`:
```
<CHE_HOST>#https://github.com/che-samples/bash?image=quay.io/dkwon17/base-developer-image:case2&storageType=per-workspace
```

Verify that `/home/user/.config/test/config2` exists, and is not a symlink:
```
$ ls -la /home/user/.config/test
total 4
drwxr-xr-x. 2 user root 21 Aug 22 21:28 .
drwxr-xr-x. 4 user root 50 Aug 22 21:27 ..
-rwxr-xr-x. 1 user root 18 Aug 22 21:28 config2
```

Make a change to the `config2` file, and restart the workspace. Once the workpsace is restarted, the `config2` file should have the changes you made before restarting the workspace.


</details>
