### PR TITLE
chore: update GitHub Actions workflows for UBI 9 and UBI 10 images

### DIFF
--- a/.github/workflows/pr-check-ubi10.yaml
+++ b/.github/workflows/pr-check-ubi10.yaml
@@ -166,50 +166,15 @@ jobs:
           echo "=========================================="
           echo "Publishing UBI10 base image manifest"
           echo "=========================================="
-          echo "Verifying all architecture images exist..."
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:amd64-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: amd64 base image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: arm64 base image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: ppc64le base image not found"
-            exit 1
-          }
-          echo "All images verified, extracting digests..."
 
-          # Extract the actual image digest for each architecture from the manifest list
-          AMD64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:amd64-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          ARM64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          PPC64LE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "ppc64le") | .digest')
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:amd64-ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-pr-${{github.event.number}}
 
-          echo "AMD64 digest: $AMD64_DIGEST"
-          echo "ARM64 digest: $ARM64_DIGEST"
-          echo "PPC64LE digest: $PPC64LE_DIGEST"
-
-          echo "Creating multi-arch manifest..."
-          docker manifest create ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}} \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$AMD64_DIGEST \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$ARM64_DIGEST \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$PPC64LE_DIGEST
-
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$AMD64_DIGEST \
-            --os linux --arch amd64
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$ARM64_DIGEST \
-            --os linux --arch arm64
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$PPC64LE_DIGEST \
-            --os linux --arch ppc64le
-
-          docker manifest push ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}}
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/base-developer-image:ubi10-pr-${{github.event.number}}
 
   publish-udi:
     name: Publish udi (UDI10)
@@ -227,50 +192,15 @@ jobs:
           echo "=========================================="
           echo "Publishing UDI10 manifest"
           echo "=========================================="
-          echo "Verifying all architecture images exist..."
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:amd64-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: amd64 UDI image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: arm64 UDI image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-pr-${{github.event.number}} || {
-            echo "ERROR: ppc64le UDI image not found"
-            exit 1
-          }
-          echo "All images verified, extracting digests..."
 
-          # Extract the actual image digest for each architecture from the manifest list
-          AMD64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:amd64-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          ARM64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          PPC64LE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "ppc64le") | .digest')
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:amd64-ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-pr-${{github.event.number}}
 
-          echo "AMD64 digest: $AMD64_DIGEST"
-          echo "ARM64 digest: $ARM64_DIGEST"
-          echo "PPC64LE digest: $ARM64_DIGEST"
-
-          echo "Creating multi-arch manifest..."
-          docker manifest create ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}} \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$AMD64_DIGEST \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$ARM64_DIGEST \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$PPC64LE_DIGEST
-
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$AMD64_DIGEST \
-            --os linux --arch amd64
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$ARM64_DIGEST \
-            --os linux --arch arm64
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$PPC64LE_DIGEST \
-            --os linux --arch ppc64le
-
-          docker manifest push ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}}
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/universal-developer-image:ubi10-pr-${{github.event.number}}
       - name: 'Comment PR'
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -165,50 +165,12 @@ jobs:
           echo "=========================================="
           echo "Publishing UBI9 base image manifest"
           echo "=========================================="
-          echo "Verifying all architecture images exist..."
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:amd64-pr-${{github.event.number}} || {
-            echo "ERROR: amd64 base image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:arm64-pr-${{github.event.number}} || {
-            echo "ERROR: arm64 base image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:ppc64le-pr-${{github.event.number}} || {
-            echo "ERROR: ppc64le base image not found"
-            exit 1
-          }
-          echo "All images verified, extracting digests..."
-
-          # Extract the actual image digest for each architecture from the manifest list
-          AMD64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:amd64-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          ARM64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:arm64-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          PPC64LE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/base-developer-image:ppc64le-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "ppc64le") | .digest')
-
-          echo "AMD64 digest: $AMD64_DIGEST"
-          echo "ARM64 digest: $ARM64_DIGEST"
-          echo "PPC64LE digest: $PPC64LE_DIGEST"
-
-          echo "Creating multi-arch manifest..."
-          docker manifest create ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}} \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$AMD64_DIGEST \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$ARM64_DIGEST \
-            --amend ${{ env.REGISTRY }}/base-developer-image@$PPC64LE_DIGEST
-
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$AMD64_DIGEST \
-            --os linux --arch amd64
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$ARM64_DIGEST \
-            --os linux --arch arm64
-          docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/base-developer-image@$PPC64LE_DIGEST \
-            --os linux --arch ppc64le
-
-          docker manifest push ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}}
+          
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/base-developer-image:pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:amd64-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:arm64-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/base-developer-image:ppc64le-pr-${{github.event.number}}
 
   publish-udi:
     name: Publish udi (UDI9)
@@ -226,50 +188,12 @@ jobs:
           echo "=========================================="
           echo "Publishing UDI9 manifest"
           echo "=========================================="
-          echo "Verifying all architecture images exist..."
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:amd64-pr-${{github.event.number}} || {
-            echo "ERROR: amd64 UDI image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:arm64-pr-${{github.event.number}} || {
-            echo "ERROR: arm64 UDI image not found"
-            exit 1
-          }
-          docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:ppc64le-pr-${{github.event.number}} || {
-            echo "ERROR: ppc64le UDI image not found"
-            exit 1
-          }
-          echo "All images verified, extracting digests..."
 
-          # Extract the actual image digest for each architecture from the manifest list
-          AMD64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:amd64-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          ARM64_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:arm64-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          PPC64LE_DIGEST=$(docker manifest inspect ${{ env.REGISTRY }}/universal-developer-image:ppc64le-pr-${{github.event.number}} | \
-            jq -r '.manifests[] | select(.platform.architecture == "ppc64le") | .digest')
-
-          echo "AMD64 digest: $AMD64_DIGEST"
-          echo "ARM64 digest: $ARM64_DIGEST"
-          echo "PPC64LE digest: $PPC64LE_DIGEST"
-
-          echo "Creating multi-arch manifest..."
-          docker manifest create ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}} \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$AMD64_DIGEST \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$ARM64_DIGEST \
-            --amend ${{ env.REGISTRY }}/universal-developer-image@$PPC64LE_DIGEST
-
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$AMD64_DIGEST \
-            --os linux --arch amd64
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$ARM64_DIGEST \
-            --os linux --arch arm64
-          docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}} \
-            ${{ env.REGISTRY }}/universal-developer-image@$PPC64LE_DIGEST \
-            --os linux --arch ppc64le
-
-          docker manifest push ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}}
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/universal-developer-image:pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:amd64-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:arm64-pr-${{github.event.number}} \
+            ${{ env.REGISTRY }}/universal-developer-image:ppc64le-pr-${{github.event.number}}
       - name: 'Comment PR'
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/ubi10-build.yaml
+++ b/.github/workflows/ubi10-build.yaml
@@ -89,24 +89,11 @@ jobs:
         run: |
           for tag in ubi10-latest ubi10-${{env.short_sha}};
           do
-            docker manifest create ${{ env.REGISTRY }}/base-developer-image:${tag} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:amd64-ubi10-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-${{env.short_sha}}
-          
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
+            docker buildx imagetools create \
+              -t ${{ env.REGISTRY }}/base-developer-image:${tag} \
               ${{ env.REGISTRY }}/base-developer-image:amd64-ubi10-${{env.short_sha}} \
-              --os linux --arch amd64
-          
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
-               ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-${{env.short_sha}} \
-              --os linux --arch arm64
-            
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
-               ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-${{env.short_sha}} \
-              --os linux --arch ppc64le
-          
-            docker manifest push ${{ env.REGISTRY }}/base-developer-image:${tag}
+              ${{ env.REGISTRY }}/base-developer-image:arm64-ubi10-${{env.short_sha}} \
+              ${{ env.REGISTRY }}/base-developer-image:ppc64le-ubi10-${{env.short_sha}}
           done
 
   build-udi:
@@ -162,6 +149,8 @@ jobs:
     name: Publish udi
     runs-on: ubuntu-22.04
     needs: build-udi
+    outputs:
+      uniq_tag: ${{ steps.setTagName.outputs.uniq_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -177,24 +166,11 @@ jobs:
         run: |
           for tag in ubi10-latest ubi10-${{env.short_sha}};
           do
-            docker manifest create ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:amd64-ubi10-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-${{env.short_sha}}
-          
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
+            docker buildx imagetools create \
+              -t ${{ env.REGISTRY }}/universal-developer-image:${tag} \
               ${{ env.REGISTRY }}/universal-developer-image:amd64-ubi10-${{env.short_sha}} \
-              --os linux --arch amd64
-          
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-               ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-${{env.short_sha}} \
-              --os linux --arch arm64
-            
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-               ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-${{env.short_sha}} \
-              --os linux --arch ppc64le
-          
-            docker manifest push ${{ env.REGISTRY }}/universal-developer-image:${tag}
+              ${{ env.REGISTRY }}/universal-developer-image:arm64-ubi10-${{env.short_sha}} \
+              ${{ env.REGISTRY }}/universal-developer-image:ppc64le-ubi10-${{env.short_sha}}
           done
       - name: Get tag with uniq prefix
         id: setTagName

--- a/.github/workflows/ubi9-build.yaml
+++ b/.github/workflows/ubi9-build.yaml
@@ -88,26 +88,13 @@ jobs:
         run: |
           for tag in latest ubi9-latest ubi9-${{env.short_sha}};
           do
-            docker manifest create ${{ env.REGISTRY }}/base-developer-image:${tag} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:amd64-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:arm64-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/base-developer-image:ppc64le-${{env.short_sha}}
-          
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
+            docker buildx imagetools create \
+              -t ${{ env.REGISTRY }}/base-developer-image:${tag} \
               ${{ env.REGISTRY }}/base-developer-image:amd64-${{env.short_sha}} \
-              --os linux --arch amd64
-          
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
-               ${{ env.REGISTRY }}/base-developer-image:arm64-${{env.short_sha}} \
-              --os linux --arch arm64
-
-            docker manifest annotate ${{ env.REGISTRY }}/base-developer-image:${tag} \
-               ${{ env.REGISTRY }}/base-developer-image:ppc64le-${{env.short_sha}} \
-              --os linux --arch ppc64le
-          
-            docker manifest push ${{ env.REGISTRY }}/base-developer-image:${tag}
+              ${{ env.REGISTRY }}/base-developer-image:arm64-${{env.short_sha}} \
+              ${{ env.REGISTRY }}/base-developer-image:ppc64le-${{env.short_sha}}
           done
-
+  
   build-udi:
     name: Build udi
     strategy:
@@ -176,24 +163,11 @@ jobs:
         run: |
           for tag in latest ubi9-latest ubi9-${{env.short_sha}};
           do
-            docker manifest create ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:amd64-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:arm64-${{env.short_sha}} \
-              --amend ${{ env.REGISTRY }}/universal-developer-image:ppc64le-${{env.short_sha}} 
-          
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
+            docker buildx imagetools create \
+              -t ${{ env.REGISTRY }}/universal-developer-image:${tag} \
               ${{ env.REGISTRY }}/universal-developer-image:amd64-${{env.short_sha}} \
-              --os linux --arch amd64
-          
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-               ${{ env.REGISTRY }}/universal-developer-image:arm64-${{env.short_sha}} \
-              --os linux --arch arm64
-          
-            docker manifest annotate ${{ env.REGISTRY }}/universal-developer-image:${tag} \
-               ${{ env.REGISTRY }}/universal-developer-image:ppc64le-${{env.short_sha}} \
-              --os linux --arch ppc64le
-
-            docker manifest push ${{ env.REGISTRY }}/universal-developer-image:${tag}
+              ${{ env.REGISTRY }}/universal-developer-image:arm64-${{env.short_sha}} \
+              ${{ env.REGISTRY }}/universal-developer-image:ppc64le-${{env.short_sha}}
           done  
       - name: Get tag with uniq prefix
         id: setTagName

--- a/universal/ubi10/Dockerfile
+++ b/universal/ubi10/Dockerfile
@@ -113,9 +113,9 @@ USER 0
 # Required packages for AWT
 RUN dnf install -y libXext libXrender libXtst libXi
 
-# Lombok
+# Lombok 
 ENV LOMBOK_VERSION=1.18.42
-RUN wget -O /usr/local/lib/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+RUN curl -fsSL -o /usr/local/lib/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 
 # Scala
 RUN curl -fLo cs https://git.io/coursier-cli && \
@@ -149,7 +149,7 @@ RUN mkdir -p $GOBIN \
     && case "$TARGETARCH" in \
         amd64) GO_ARCH="amd64" ;; \
         arm64) GO_ARCH="arm64" ;; \
-        ppc64le) GO_ARCH="ppc64" ;; \
+        ppc64le) GO_ARCH="ppc64le" ;; \
         *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
     esac \
     && GO_VERSION="1.25.5" \
@@ -157,7 +157,11 @@ RUN mkdir -p $GOBIN \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm -rf /tmp/go.tar.gz \
     && go version \
-    && GO111MODULE=on go install golang.org/x/tools/gopls@v0.21.0 \
+    && if [ "$TARGETARCH" = "ppc64le" ]; then \
+         CGO_ENABLED=0 GO111MODULE=on go install golang.org/x/tools/gopls@v0.21.0; \
+       else \
+         GO111MODULE=on go install golang.org/x/tools/gopls@v0.21.0; \
+       fi \
     && chgrp -R 0 /home/tooling \
     && chmod -R g=u /home/tooling
 
@@ -399,7 +403,7 @@ case "$TARGETARCH" in
         TKN_ARCH="Linux_x86_64"
         ;;
     arm64)
-        TKN_ARCH="Linux_arm64"
+        TKN_ARCH="Linux_aarch64"
         ;;
     ppc64le)
         TKN_ARCH="Linux_ppc64le"


### PR DESCRIPTION
Updated GitHub Actions workflows for UBI 9 and UBI 10 developer images.

Changes include:
> PR check workflows for UBI 10 images.
> Main build and publish workflows for UBI 9 and UBI 10 images.
> Unified tagging using short SHA for unique image versions.
> Multi-architecture support (amd64, arm64, ppc64le) for both base and UDI images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined multi-architecture image publication using buildx imagetools for simpler, more reliable multi-arch tagging.
  * Exposed a generated unique build tag for downstream workflow steps.
* **Bug Fixes / Reliability**
  * Made Java utility download more robust (switched to a more reliable fetch method).
  * Corrected PPC64LE architecture mapping and adjusted tool install behavior (disabled CGO where required); fixed ARM64 release archive mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->