### PR TITLE
feat: Add goose CLI `v1.28.0` to universal developer image

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ docker run -ti --rm quay.io/devfile/universal-developer-image:ubi9-latest bash
 | `docker`            |`<download.docker.com>`              |
 | `docker-compose`    |`<gh releases>`                      |
 | `kamel`             |`<gh release>`                       |
+|-----AI TOOLING------|-------------------------------------|
+| `goose`             |`<gh releases> v1.28.0`              |
 | **TOTAL SIZE**      | **8.75GB** (3.6GB compressed)       |
 
 **Libraries:**

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -107,11 +107,31 @@ ENV KUBECONFIG=/home/user/.kube/config
 USER 0
 
 # Required packages for AWT
-RUN dnf install -y libXext libXrender libXtst libXi
+RUN dnf install -y libXext libXrender libXtst libXi bzip2
 
 # Lombok
 ENV LOMBOK_VERSION=1.18.18
 RUN wget -O /usr/local/lib/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+
+# Goose CLI
+ENV GOOSE_VERSION=v1.28.0
+RUN mkdir -p /opt/goose-install && \
+    curl -L -o /opt/goose-install/goose.tar.bz2 \
+    https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-x86_64-unknown-linux-gnu.tar.bz2 && \
+    tar -xjf /opt/goose-install/goose.tar.bz2 -C /opt/goose-install && \
+    mv /opt/goose-install/goose /usr/local/bin/goose && \
+    chmod +x /usr/local/bin/goose && \
+    rm -rf /opt/goose-install
+
+# pre-create the nested folders Goose expects to avoid "Permission Denied" at runtime
+RUN mkdir -p \
+    /home/user/.local/bin \
+    /home/user/.local/share/goose \
+    /home/user/.local/state/goose/logs \
+    /home/user/.config/goose \
+    /home/user/.cache/goose && \
+    chown -R 10001:0 /home/user/.local && \
+    chmod -R g=u /home/user
 
 # Scala
 RUN curl -fLo cs https://git.io/coursier-cli && \


### PR DESCRIPTION
## Description

Add [`goose` CLI AI assistant tool](https://block.github.io/goose/docs/quickstart) to the UBI9 universal developer image. 
- Includes `bzip2` dependency for extraction
- Add pre-configured directories with proper permissions for `goose` runtime.
  - Add RUN statement for `goose` runtime configuration to properly set up directory     
     permissions before the container switches to non-root user 10001. Goose requires        
     these directories at runtime for configuration like `~/.config/goose/config.yaml` , but user 10001 lacks permissions to create  them on-demand. Pre-creating with correct ownership (10001:0) and group permissions     
    prevents "Permission Denied" errors when `goose` is run inside container.

 ## How to test?

You can test it by creating a workspace based on this [repo](https://github.com/rohankanojia-forks/cli-ai-tools/tree/pr/add-goose-cli-testing). It uses image I created based on this branch.

## Demo


https://github.com/user-attachments/assets/99fc5ab6-09e5-454b-b890-1b963324c93c