### PR TITLE
feat: adding gcloud CLI to ubi9 and ubi10

### DIFF
--- a/universal/ubi10/Dockerfile
+++ b/universal/ubi10/Dockerfile
@@ -472,6 +472,41 @@ fi
 RUN curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-${TARGETARCH} && \
     install skaffold /usr/local/bin/
 
+## Google Cloud CLI
+RUN <<EOF
+set -euf -o pipefail
+TEMP_DIR="$(mktemp -d)"
+cd "${TEMP_DIR}"
+
+GCLOUD_VERSION="512.0.0"
+
+case "$TARGETARCH" in
+    amd64)
+        GCLOUD_ARCH="x86_64"
+        ;;
+    arm64)
+        GCLOUD_ARCH="arm"
+        ;;
+    *)
+        echo "Skipping gcloud installation for unsupported architecture: $TARGETARCH"
+        exit 0
+        ;;
+esac
+
+GCLOUD_TGZ="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"
+GCLOUD_TGZ_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TGZ}"
+
+curl -sSLO "${GCLOUD_TGZ_URL}"
+tar -xzf "${GCLOUD_TGZ}"
+./google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --quiet
+mv google-cloud-sdk /usr/local/
+
+cd -
+rm -rf "${TEMP_DIR}"
+EOF
+
+ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}"
+
 # e2fsprogs setup
 # Since e2fsprogs-static package has removed RHEL 8 distribution, it is not possible to install from the repository
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#removed-packages_changes-to-packages
@@ -520,6 +555,9 @@ oc completion bash > /usr/share/bash-completion/completions/oc
 tkn completion bash > /usr/share/bash-completion/completions/tkn
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
+if [ -f /usr/local/google-cloud-sdk/completion.bash.inc ]; then
+    cat /usr/local/google-cloud-sdk/completion.bash.inc > /usr/share/bash-completion/completions/gcloud
+fi
 EOF
 
 ## Add sdkman's init script launcher to the end of ${PROFILE_EXT} since we are not adding it on sdkman install

--- a/universal/ubi10/Dockerfile
+++ b/universal/ubi10/Dockerfile
@@ -478,7 +478,7 @@ set -euf -o pipefail
 TEMP_DIR="$(mktemp -d)"
 cd "${TEMP_DIR}"
 
-GCLOUD_VERSION="512.0.0"
+GCLOUD_VERSION="565.0.0"
 
 case "$TARGETARCH" in
     amd64)

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -446,7 +446,7 @@ set -euf -o pipefail
 TEMP_DIR="$(mktemp -d)"
 cd "${TEMP_DIR}"
 
-GCLOUD_VERSION="512.0.0"
+GCLOUD_VERSION="565.0.0"
 
 case "$TARGETARCH" in
     amd64)

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -440,6 +440,41 @@ fi
 RUN curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-${TARGETARCH} && \
     install skaffold /usr/local/bin/
 
+## Google Cloud CLI
+RUN <<EOF
+set -euf -o pipefail
+TEMP_DIR="$(mktemp -d)"
+cd "${TEMP_DIR}"
+
+GCLOUD_VERSION="512.0.0"
+
+case "$TARGETARCH" in
+    amd64)
+        GCLOUD_ARCH="x86_64"
+        ;;
+    arm64)
+        GCLOUD_ARCH="arm"
+        ;;
+    *)
+        echo "Skipping gcloud installation for unsupported architecture: $TARGETARCH"
+        exit 0
+        ;;
+esac
+
+GCLOUD_TGZ="google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz"
+GCLOUD_TGZ_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TGZ}"
+
+curl -sSLO "${GCLOUD_TGZ_URL}"
+tar -xzf "${GCLOUD_TGZ}"
+./google-cloud-sdk/install.sh --usage-reporting=false --path-update=false --quiet
+mv google-cloud-sdk /usr/local/
+
+cd -
+rm -rf "${TEMP_DIR}"
+EOF
+
+ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}"
+
 # e2fsprogs setup
 # Since e2fsprogs-static package has removed RHEL 8 distribution, it is not possible to install from the repository
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#removed-packages_changes-to-packages
@@ -488,6 +523,9 @@ oc completion bash > /usr/share/bash-completion/completions/oc
 tkn completion bash > /usr/share/bash-completion/completions/tkn
 kubectl completion bash > /usr/share/bash-completion/completions/kubectl
 cat ${NVM_DIR}/bash_completion > /usr/share/bash-completion/completions/nvm
+if [ -f /usr/local/google-cloud-sdk/completion.bash.inc ]; then
+    cat /usr/local/google-cloud-sdk/completion.bash.inc > /usr/share/bash-completion/completions/gcloud
+fi
 EOF
 
 ## Add sdkman's init script launcher to the end of ${PROFILE_EXT} since we are not adding it on sdkman install


### PR DESCRIPTION
https://docs.cloud.google.com/sdk/gcloud 

````
ibuziuk@ibuziuk-mac google-cloud-sdk % cat LICENSE 
The Google Cloud CLI and its source code are licensed under Apache
License v. 2.0 (the "License"), unless otherwise specified by an alternate
license file.

You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Note that if you use the Google Cloud CLI with any Google Cloud Platform
products, your use is additionally going to be governed by the license agreement
or terms of service, as applicable, of the underlying Google Cloud Platform
product with which you are using the Google Cloud CLI. For example, if you are
using the Google Cloud CLI with Google App Engine, your use would additionally
be governed by the Google App Engine Terms of Service.

This also means that if you were to create works that call Google APIs, you
would still need to agree to the terms of service (usually, Google's
Developer Terms of Service at https://developers.google.com/terms) for those
APIs separately, as this code does not grant you any special rights to use
the services.
````
