### PR TITLE
feat: add Node.js 22 and update Node.js versions for ubi9

### DIFF
--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -85,19 +85,22 @@ ENV PATH="/home/tooling/.local/share/coursier/bin:$PATH"
 # NodeJS
 RUN mkdir -p /home/tooling/.nvm/
 ENV NVM_DIR="/home/tooling/.nvm"
-ENV NODEJS_20_VERSION=20.18.1
-ENV NODEJS_18_VERSION=18.20.5
-ENV NODEJS_DEFAULT_VERSION=${NODEJS_20_VERSION}
+ENV NODEJS_22_VERSION=22.22.3
+ENV NODEJS_20_VERSION=20.20.2
+ENV NODEJS_18_VERSION=18.20.8
+ENV NODEJS_DEFAULT_VERSION=${NODEJS_22_VERSION}
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | PROFILE=/dev/null bash
 RUN echo 'export NVM_DIR="$HOME/.nvm"' >> ${PROFILE_EXT} \
     && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ${PROFILE_EXT}
 RUN source /home/user/.bashrc && \
+    nvm install v${NODEJS_22_VERSION} && \
     nvm install v${NODEJS_20_VERSION} && \
     nvm install v${NODEJS_18_VERSION} && \
     nvm alias default v${NODEJS_DEFAULT_VERSION} && nvm use v${NODEJS_DEFAULT_VERSION} && \
     npm install --global yarn@v1.22.22 &&\
     chgrp -R 0 /home/tooling && chmod -R g=u /home/tooling
 ENV PATH=$NVM_DIR/versions/node/v${NODEJS_DEFAULT_VERSION}/bin:$PATH
+ENV NODEJS_HOME_22=$NVM_DIR/versions/node/v${NODEJS_22_VERSION}
 ENV NODEJS_HOME_20=$NVM_DIR/versions/node/v${NODEJS_20_VERSION}
 ENV NODEJS_HOME_18=$NVM_DIR/versions/node/v${NODEJS_18_VERSION}
 


### PR DESCRIPTION
Add Node.js 22.22.3 as the new default, update Node.js 20 to 20.20.2 and Node.js 18 to 18.20.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Node.js toolchain with Node.js 22 (new default), upgraded Node.js 20 to v20.20.2, and Node.js 18 to v18.20.8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devfile/developer-images/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->