### PR TITLE
base: Verify GitHub CLI `gh` download via checksums file

### DIFF
--- a/base/ubi10/Dockerfile
+++ b/base/ubi10/Dockerfile
@@ -66,9 +66,13 @@ RUN \
     esac && \
     GH_TGZ="gh_${GH_VERSION}_${GH_ARCH}.tar.gz" && \
     GH_TGZ_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TGZ}" && \
+    GH_CHECKSUMS="gh_${GH_VERSION}_checksums.txt" && \
+    GH_CHECKSUMS_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_CHECKSUMS}" && \
     echo "Downloading ${GH_TGZ_URL}..." && \
     if curl -fsSL "${GH_TGZ_URL}" -o "${GH_TGZ}"; then \
-        if file "${GH_TGZ}" | grep -q 'gzip compressed'; then \
+        curl -fsSL "${GH_CHECKSUMS_URL}" -o "${GH_CHECKSUMS}" && \
+        grep -F -e " ${GH_TGZ}" "${GH_CHECKSUMS}" > "${GH_TGZ}.sha256" && \
+        if sha256sum -c "${GH_TGZ}.sha256"; then \
             tar -zxv --no-same-owner -f "${GH_TGZ}" && \
             mv "gh_${GH_VERSION}_${GH_ARCH}"/bin/gh /usr/local/bin/ && \
             mv "gh_${GH_VERSION}_${GH_ARCH}"/share/man/man1/* /usr/local/share/man/man1; \

--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -49,9 +49,13 @@ RUN \
     esac && \
     GH_TGZ="gh_${GH_VERSION}_${GH_ARCH}.tar.gz" && \
     GH_TGZ_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TGZ}" && \
+    GH_CHECKSUMS="gh_${GH_VERSION}_checksums.txt" && \
+    GH_CHECKSUMS_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_CHECKSUMS}" && \
     echo "Downloading ${GH_TGZ_URL}..." && \
     if curl -fsSL "${GH_TGZ_URL}" -o "${GH_TGZ}"; then \
-        if file "${GH_TGZ}" | grep -q 'gzip compressed'; then \
+        curl -fsSL "${GH_CHECKSUMS_URL}" -o "${GH_CHECKSUMS}" && \
+        grep -F -e " ${GH_TGZ}" "${GH_CHECKSUMS}" > "${GH_TGZ}.sha256" && \
+        if sha256sum -c "${GH_TGZ}.sha256"; then \
             tar -zxv --no-same-owner -f "${GH_TGZ}" && \
             mv "gh_${GH_VERSION}_${GH_ARCH}"/bin/gh /usr/local/bin/ && \
             mv "gh_${GH_VERSION}_${GH_ARCH}"/share/man/man1/* /usr/local/share/man/man1; \


### PR DESCRIPTION
Current build skips over the gh CLI package because of missing `file` command. Better to just verify the sha256 of the archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Updated UBI10 and UBI9 base images to verify GitHub CLI tarball downloads using SHA-256 checksum validation. The Docker build process now downloads the corresponding checksums file, extracts the expected hash, and validates integrity before proceeding with installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devfile/developer-images/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->