### PR TITLE
base: Use bat, fd, rg from dnf repos

### DIFF
--- a/base/ubi10/Dockerfile
+++ b/base/ubi10/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     \
     # Install the main list of packages (no full system update)
     dnf install -y --setopt=install_weak_deps=False \
-        diffutils git git-lfs iproute jq less lsof man nano procps \
+        bat diffutils fd-find git git-lfs iproute jq less lsof man nano procps \
         p7zip p7zip-plugins perl-Digest-SHA net-tools \
         openssh-clients openssl ripgrep rsync socat sudo \
         time vim wget zip && \
@@ -79,118 +79,6 @@ RUN \
         echo "gh binary not found for ${TARGETARCH}, skipping installation."; \
     fi && \
     cd - && rm -rf "${TEMP_DIR}"
-
-# Download and install ripgrep depending on the architecture.
-# See release page for details https://github.com/BurntSushi/ripgrep/releases/tag/13.0.0
-
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping ripgrep installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            RG_ARCH="arm-unknown-linux-gnueabihf" ;; \
-        amd64) \
-            RG_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for ripgrep: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    RG_VERSION="13.0.0"; \
-    RG_TGZ="ripgrep-${RG_VERSION}-${RG_ARCH}.tar.gz"; \
-    RG_TGZ_URL="https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TGZ}"; \
-    echo "Downloading ${RG_TGZ_URL} ..."; \
-    if curl -fsSL "${RG_TGZ_URL}" -o "${RG_TGZ}"; then \
-        if file "${RG_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -zxf "${RG_TGZ}" --no-same-owner; \
-            install -m 0755 "ripgrep-${RG_VERSION}-${RG_ARCH}/rg" /usr/local/bin/rg; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "ripgrep-${RG_VERSION}-${RG_ARCH}/doc/rg.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded ripgrep archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "ripgrep binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
-
-
-# Download and install bat depending on the architecture.
-# See release page for details https://github.com/sharkdp/bat/releases/tag/v0.18.3
-
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping bat installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            BAT_ARCH="aarch64-unknown-linux-gnu" ;; \
-        amd64) \
-            BAT_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for bat: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    BAT_VERSION="v0.18.3"; \
-    BAT_TGZ="bat-v${BAT_VERSION}-${BAT_ARCH}.tar.gz"; \
-    BAT_TGZ_URL="https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/${BAT_TGZ}"; \
-    echo "Downloading ${BAT_TGZ_URL} ..."; \
-    if curl -fsSL "${BAT_TGZ_URL}" -o "${BAT_TGZ}"; then \
-        if file "${BAT_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -zxf "${BAT_TGZ}" --no-same-owner; \
-            install -m 0755 "bat-v${BAT_VERSION}-${BAT_ARCH}/bat" /usr/local/bin/bat; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "bat-v${BAT_VERSION}-${BAT_ARCH}/bat.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded bat archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "bat binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
-
-# Download and install fd depending on the architecture.
-# See release page for details https://github.com/sharkdp/fd/releases/tag/v8.7.0
-
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping fd installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            FD_ARCH="aarch64-unknown-linux-gnu" ;; \
-        amd64) \
-            FD_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for fd: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    FD_VERSION="8.7.0"; \
-    FD_TGZ="fd-v${FD_VERSION}-${FD_ARCH}.tar.gz"; \
-    FD_TGZ_URL="https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/${FD_TGZ}"; \
-    echo "Downloading ${FD_TGZ_URL} ..."; \
-    if curl -fsSL "${FD_TGZ_URL}" -o "${FD_TGZ}"; then \
-        if file "${FD_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -xf "${FD_TGZ}" --no-same-owner; \
-            install -m 0755 "fd-v${FD_VERSION}-${FD_ARCH}/fd" /usr/local/bin/fd; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "fd-v${FD_VERSION}-${FD_ARCH}/fd.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded fd archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "fd binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
 
 # Define user directory for binaries
 ENV PATH="/home/user/.local/bin:$PATH"

--- a/base/ubi9/Dockerfile
+++ b/base/ubi9/Dockerfile
@@ -26,8 +26,9 @@ RUN mkdir -p /home/tooling/
 
 ## add epel repos so that p7zip p7zip-plugins stow can be found
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    dnf install -y diffutils git git-lfs iproute jq less lsof man nano procps p7zip p7zip-plugins \
-        perl-Digest-SHA net-tools openssh-clients rsync socat sudo time vim wget zip stow && \
+    dnf install -y bat diffutils fd-find git git-lfs iproute jq less lsof man \
+        nano procps p7zip p7zip-plugins perl-Digest-SHA net-tools \
+        openssh-clients ripgrep rsync socat sudo time vim wget zip stow && \
     dnf update -y && \
     dnf clean all
 
@@ -62,114 +63,6 @@ RUN \
         echo "gh binary not found for ${TARGETARCH}, skipping installation."; \
     fi && \
     cd - && rm -rf "${TEMP_DIR}"
-
-# Download and install ripgrep depending on the architecture.
-# See release page for details https://github.com/BurntSushi/ripgrep/releases/tag/15.1.0
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping ripgrep installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            RG_ARCH="arm-unknown-linux-gnueabihf" ;; \
-        amd64) \
-            RG_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for ripgrep: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    RG_VERSION="15.1.0"; \
-    RG_TGZ="ripgrep-${RG_VERSION}-${RG_ARCH}.tar.gz"; \
-    RG_TGZ_URL="https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TGZ}"; \
-    echo "Downloading ${RG_TGZ_URL} ..."; \
-    if curl -fsSL "${RG_TGZ_URL}" -o "${RG_TGZ}"; then \
-        if file "${RG_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -zxf "${RG_TGZ}" --no-same-owner; \
-            install -m 0755 "ripgrep-${RG_VERSION}-${RG_ARCH}/rg" /usr/local/bin/rg; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "ripgrep-${RG_VERSION}-${RG_ARCH}/doc/rg.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded ripgrep archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "ripgrep binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
-
-# Download and install bat depending on the architecture.
-# See release page for details https://github.com/sharkdp/bat/releases/tag/v0.26.0
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping bat installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            BAT_ARCH="aarch64-unknown-linux-gnu" ;; \
-        amd64) \
-            BAT_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for bat: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    BAT_VERSION="v0.26.0"; \
-    BAT_TGZ="bat-v${BAT_VERSION}-${BAT_ARCH}.tar.gz"; \
-    BAT_TGZ_URL="https://github.com/sharkdp/bat/releases/download/v${BAT_VERSION}/${BAT_TGZ}"; \
-    echo "Downloading ${BAT_TGZ_URL} ..."; \
-    if curl -fsSL "${BAT_TGZ_URL}" -o "${BAT_TGZ}"; then \
-        if file "${BAT_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -zxf "${BAT_TGZ}" --no-same-owner; \
-            install -m 0755 "bat-v${BAT_VERSION}-${BAT_ARCH}/bat" /usr/local/bin/bat; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "bat-v${BAT_VERSION}-${BAT_ARCH}/bat.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded bat archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "bat binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
-
-# Download and install fd depending on the architecture.
-# See release page for details https://github.com/sharkdp/fd/releases/tag/v10.3.0
-RUN set -e; \
-    case "$TARGETARCH" in \
-        ppc64le) \
-            echo "Skipping fd installation for ppc64le as binary not available"; \
-            exit 0 ;; \
-        arm64) \
-            FD_ARCH="aarch64-unknown-linux-gnu" ;; \
-        amd64) \
-            FD_ARCH="x86_64-unknown-linux-musl" ;; \
-        *) \
-            echo "Unsupported architecture for fd: $TARGETARCH"; \
-            exit 0 ;; \
-    esac; \
-    TEMP_DIR="$(mktemp -d)"; \
-    cd "${TEMP_DIR}"; \
-    FD_VERSION="10.3.0"; \
-    FD_TGZ="fd-v${FD_VERSION}-${FD_ARCH}.tar.gz"; \
-    FD_TGZ_URL="https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/${FD_TGZ}"; \
-    echo "Downloading ${FD_TGZ_URL} ..."; \
-    if curl -fsSL "${FD_TGZ_URL}" -o "${FD_TGZ}"; then \
-        if file "${FD_TGZ}" | grep -q 'gzip compressed'; then \
-            tar -xf "${FD_TGZ}" --no-same-owner; \
-            install -m 0755 "fd-v${FD_VERSION}-${FD_ARCH}/fd" /usr/local/bin/fd; \
-            mkdir -p /usr/local/share/man/man1; \
-            install -m 0644 "fd-v${FD_VERSION}-${FD_ARCH}/fd.1" /usr/local/share/man/man1/; \
-        else \
-            echo "Downloaded fd archive invalid — skipping."; \
-        fi; \
-    else \
-        echo "fd binary not found for ${TARGETARCH}, skipping installation."; \
-    fi; \
-    cd - >/dev/null; \
-    rm -rf "${TEMP_DIR}"
 
 # Define user directory for binaries
 ENV PATH="/home/user/.local/bin:$PATH"


### PR DESCRIPTION
Using the distro/EPEL packages fixes the broken arch detection in the shell script used to download the releases from GitHub. Also it looks like these packages are available for ppc64 and s390x, in addition to x86_64 and aarch64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined container image builds by installing CLI tools via package manager instead of manual downloads.
  * Updated container default behavior to remain active during runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devfile/developer-images/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->