### PR TITLE
feat: add bubblewrap to UDI 9 / 10

### DIFF
--- a/universal/ubi10/Dockerfile
+++ b/universal/ubi10/Dockerfile
@@ -589,7 +589,33 @@ rm -rf "${TEMP_DIR}"
 EOF
 
 ## bubblewrap - unprivileged sandboxing tool (https://github.com/containers/bubblewrap)
-RUN dnf install -y --enablerepo=crb bubblewrap && dnf clean all && rm -rf /var/cache/dnf
+## Building from source as the package requires the crb repo which needs a RHEL subscription (not available in UBI)
+RUN <<'EOF'
+set -euf -o pipefail
+
+BWRAP_VERSION="0.11.2"
+TEMP_DIR="$(mktemp -d)"
+cd "${TEMP_DIR}"
+
+dnf install -y meson ninja-build gcc libcap-devel
+
+BWRAP_TGZ="bubblewrap-${BWRAP_VERSION}.tar.xz"
+BWRAP_URL="https://github.com/containers/bubblewrap/releases/download/v${BWRAP_VERSION}"
+curl -sSLO "${BWRAP_URL}/${BWRAP_TGZ}"
+curl -sSLO "${BWRAP_URL}/${BWRAP_TGZ}.sha256sum"
+sha256sum -c "${BWRAP_TGZ}.sha256sum"
+
+tar -xf "${BWRAP_TGZ}"
+cd "bubblewrap-${BWRAP_VERSION}"
+meson setup build
+ninja -C build
+install -m 4755 build/bwrap /usr/bin/bwrap
+
+cd /
+rm -rf "${TEMP_DIR}"
+dnf remove -y meson ninja-build gcc libcap-devel
+dnf clean all && rm -rf /var/cache/dnf
+EOF
 
 RUN <<EOF
 oc completion bash > /usr/share/bash-completion/completions/oc

--- a/universal/ubi10/Dockerfile
+++ b/universal/ubi10/Dockerfile
@@ -588,6 +588,9 @@ cd -
 rm -rf "${TEMP_DIR}"
 EOF
 
+## bubblewrap - unprivileged sandboxing tool (https://github.com/containers/bubblewrap)
+RUN dnf install -y --enablerepo=crb bubblewrap && dnf clean all && rm -rf /var/cache/dnf
+
 RUN <<EOF
 oc completion bash > /usr/share/bash-completion/completions/oc
 tkn completion bash > /usr/share/bash-completion/completions/tkn

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -555,6 +555,9 @@ cd -
 rm -rf "${TEMP_DIR}"
 EOF
 
+## bubblewrap - unprivileged sandboxing tool (https://github.com/containers/bubblewrap)
+RUN dnf install -y --enablerepo=crb bubblewrap && dnf clean all && rm -rf /var/cache/dnf
+
 RUN <<EOF
 oc completion bash > /usr/share/bash-completion/completions/oc
 tkn completion bash > /usr/share/bash-completion/completions/tkn

--- a/universal/ubi9/Dockerfile
+++ b/universal/ubi9/Dockerfile
@@ -556,7 +556,33 @@ rm -rf "${TEMP_DIR}"
 EOF
 
 ## bubblewrap - unprivileged sandboxing tool (https://github.com/containers/bubblewrap)
-RUN dnf install -y --enablerepo=crb bubblewrap && dnf clean all && rm -rf /var/cache/dnf
+## Building from source as the package requires the crb repo which needs a RHEL subscription (not available in UBI)
+RUN <<'EOF'
+set -euf -o pipefail
+
+BWRAP_VERSION="0.11.2"
+TEMP_DIR="$(mktemp -d)"
+cd "${TEMP_DIR}"
+
+dnf install -y meson ninja-build gcc libcap-devel
+
+BWRAP_TGZ="bubblewrap-${BWRAP_VERSION}.tar.xz"
+BWRAP_URL="https://github.com/containers/bubblewrap/releases/download/v${BWRAP_VERSION}"
+curl -sSLO "${BWRAP_URL}/${BWRAP_TGZ}"
+curl -sSLO "${BWRAP_URL}/${BWRAP_TGZ}.sha256sum"
+sha256sum -c "${BWRAP_TGZ}.sha256sum"
+
+tar -xf "${BWRAP_TGZ}"
+cd "bubblewrap-${BWRAP_VERSION}"
+meson setup build
+ninja -C build
+install -m 4755 build/bwrap /usr/bin/bwrap
+
+cd /
+rm -rf "${TEMP_DIR}"
+dnf remove -y meson ninja-build gcc libcap-devel
+dnf clean all && rm -rf /var/cache/dnf
+EOF
 
 RUN <<EOF
 oc completion bash > /usr/share/bash-completion/completions/oc


### PR DESCRIPTION
https://github.com/containers/bubblewrap - Low-level unprivileged sandboxing tool used by Flatpak and similar projects



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bubblewrap (`bwrap`) sandboxing to the UBI 9 and UBI 10 container images, installed from a pinned release with integrity verification.
* **Chores**
  * Reduced image size by removing build dependencies and cleaning package manager metadata/caches after installing bubblewrap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->